### PR TITLE
Fixes for the start row id

### DIFF
--- a/fetch_worker.go
+++ b/fetch_worker.go
@@ -85,7 +85,7 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 
 		for _, row := range rows {
 			position := common.TablePosition{
-				LastRead:    start,
+				LastRead:    row[string(w.config.primaryKey)].(int64),
 				SnapshotEnd: end,
 			}
 			data, err := w.buildFetchData(row, position)
@@ -101,7 +101,7 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 				)
 			}
 		}
-		start = rows[len(rows)-1][string(w.config.primaryKey)].(int64)
+		start = rows[len(rows)-1][string(w.config.primaryKey)].(int64) + 1
 	}
 
 	return nil


### PR DESCRIPTION
### Description

Adds a function that sets the start row to the minimum rowid in the table. Its just a straight copy of the existing `getMaxValue` function. 

Also fixes the start id increment to accommodate when row ids are not consecutive

Fixes #52

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [ ] I have NOT written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.