### PR TITLE
prevent avro uint64 encoding failure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     # - forbidigo
     - forcetypeassert
     # - funlen

--- a/combined_iterator.go
+++ b/combined_iterator.go
@@ -37,7 +37,7 @@ type combinedIterator struct {
 type combinedIteratorConfig struct {
 	db                    *sqlx.DB
 	tableKeys             common.TableKeys
-	fetchSize             int
+	fetchSize             int64
 	startSnapshotPosition *common.SnapshotPosition
 	startCdcPosition      *common.CdcPosition
 	database              string

--- a/common/config.go
+++ b/common/config.go
@@ -31,7 +31,7 @@ type SourceConfig struct {
 	DisableCanalLogs bool `json:"disableCanalLogs"`
 
 	// FetchSize limits how many rows should be retrieved on each database fetch.
-	FetchSize int `json:"fetchSize" default:"50000"`
+	FetchSize int64 `json:"fetchSize" default:"50000"`
 }
 
 const DefaultFetchSize = 50000

--- a/common/utils.go
+++ b/common/utils.go
@@ -17,6 +17,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -40,6 +41,13 @@ func FormatValue(val any) any {
 			return parsed.UTC().Format(time.RFC3339)
 		}
 		return s
+	case uint64:
+		if val <= math.MaxInt64 {
+			return int64(val)
+		}
+
+		// this will make avro encoding fail, as it doesn't support uint64.
+		return val
 	default:
 		return val
 	}

--- a/fetch_worker.go
+++ b/fetch_worker.go
@@ -36,7 +36,7 @@ type fetchWorker struct {
 type fetchWorkerConfig struct {
 	lastPosition common.SnapshotPosition
 	table        common.TableName
-	fetchSize    int
+	fetchSize    int64
 	primaryKey   common.PrimaryKeyName
 }
 
@@ -49,9 +49,21 @@ func newFetchWorker(db *sqlx.DB, data chan fetchData, config fetchWorkerConfig) 
 }
 
 func (w *fetchWorker) fetchStartEnd(ctx context.Context) (err error) {
-	w.start = w.config.lastPosition.Snapshots[w.config.table].LastRead
-	w.end, err = w.getMaxValue(ctx)
-	return err
+	lastRead := w.config.lastPosition.Snapshots[w.config.table].LastRead
+	minVal, maxVal, err := w.getMinMaxValue(ctx)
+	if err != nil {
+		return err
+	}
+
+	if lastRead > minVal {
+		// last read takes preference, as previous records where already fetched
+		w.start = lastRead
+	} else {
+		w.start = minVal
+	}
+	w.end = maxVal
+
+	return nil
 }
 
 func (w *fetchWorker) run(ctx context.Context) (err error) {
@@ -70,21 +82,32 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 
 	defer func() { err = errors.Join(err, tx.Commit()) }()
 
-	start, end := w.start, w.end
-	for {
-		rows, err := w.selectRowsChunk(ctx, tx, start, end)
+	sdk.Logger(ctx).Info().
+		Int64("start", w.start).
+		Int64("end", w.end).
+		Int64("fetchSize", w.config.fetchSize).
+		Msg("fetching rows")
+
+	for chunkStart := w.start; chunkStart <= w.end; chunkStart += w.config.fetchSize {
+		chunkEnd := chunkStart + w.config.fetchSize
+		sdk.Logger(ctx).Info().
+			Int64("start", chunkStart).
+			// the where clause is exclusive on the end
+			Int64("end", chunkEnd-1).
+			Msg("fetching new rows chunk")
+		rows, err := w.selectRowsChunk(ctx, tx, chunkStart, chunkEnd)
 		if err != nil {
 			return fmt.Errorf("failed to select rows chunk: %w", err)
 		}
 		if len(rows) == 0 {
-			break
+			continue
 		}
 
 		for _, row := range rows {
-			start++
+			sdk.Logger(ctx).Trace().Msgf("fetched row: %+v", row)
 			position := common.TablePosition{
-				LastRead:    start,
-				SnapshotEnd: end,
+				LastRead:    chunkStart,
+				SnapshotEnd: w.end,
 			}
 			data, err := w.buildFetchData(row, position)
 			if err != nil {
@@ -104,31 +127,53 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 	return nil
 }
 
-// getMaxValue fetches the maximum value of the primary key from the table.
-func (w *fetchWorker) getMaxValue(ctx context.Context) (int64, error) {
+// getMinMaxValue fetches the maximum value of the primary key from the table.
+func (w *fetchWorker) getMinMaxValue(ctx context.Context) (minVal, maxVal int64, err error) {
+	var minValueRow struct {
+		MinValue *int64 `db:"min_value"`
+	}
+
+	query := fmt.Sprintf(
+		"SELECT MIN(%s) as min_value FROM %s",
+		w.config.primaryKey, w.config.table,
+	)
+	row := w.db.QueryRowxContext(ctx, query)
+	if err := row.StructScan(&minValueRow); err != nil {
+		return 0, 0, fmt.Errorf("failed to get min value: %w", err)
+	}
+
+	if err := row.Err(); err != nil {
+		return 0, 0, fmt.Errorf("failed to get min value: %w", err)
+	}
+
+	if minValueRow.MinValue == nil {
+		// table is empty
+		return 0, 0, nil
+	}
+
 	var maxValueRow struct {
 		MaxValue *int64 `db:"max_value"`
 	}
 
-	query := fmt.Sprintf(
+	query = fmt.Sprintf(
 		"SELECT MAX(%s) as max_value FROM %s",
 		w.config.primaryKey, w.config.table,
 	)
-	row := w.db.QueryRowxContext(ctx, query)
+	row = w.db.QueryRowxContext(ctx, query)
 	if err := row.StructScan(&maxValueRow); err != nil {
-		return 0, fmt.Errorf("failed to get max value: %w", err)
+		return 0, 0, fmt.Errorf("failed to get max value: %w", err)
 	}
 
 	if err := row.Err(); err != nil {
-		return 0, fmt.Errorf("failed to get max value: %w", err)
+		return 0, 0, fmt.Errorf("failed to get max value: %w", err)
 	}
 
 	if maxValueRow.MaxValue == nil {
 		// table is empty
-		return 0, nil
+		return 0, 0, nil
 	}
 
-	return *maxValueRow.MaxValue, nil
+	return *minValueRow.MinValue, *maxValueRow.MaxValue, nil
 }
 
 func (w *fetchWorker) selectRowsChunk(
@@ -138,9 +183,9 @@ func (w *fetchWorker) selectRowsChunk(
 	query := fmt.Sprint(`
 		SELECT *
 		FROM `, w.config.table, `
-		WHERE `, w.config.primaryKey, ` > ? AND `, w.config.primaryKey, ` <= ?
-		ORDER BY `, w.config.primaryKey, ` LIMIT ?
-	`)
+		WHERE `, w.config.primaryKey, ` >= ? AND `, w.config.primaryKey, ` < ?
+		ORDER BY `, w.config.primaryKey,
+	)
 	logDataEvt := sdk.Logger(ctx).Debug().
 		Any("data", opencdc.StructuredData{
 			"query":     query,
@@ -149,7 +194,7 @@ func (w *fetchWorker) selectRowsChunk(
 			"fetchSize": w.config.fetchSize,
 		})
 
-	rows, err := tx.QueryxContext(ctx, query, start, end, w.config.fetchSize)
+	rows, err := tx.QueryxContext(ctx, query, start, end)
 	if err != nil {
 		logDataEvt.Msg("failed to query rows")
 		return nil, fmt.Errorf("failed to query rows: %w", err)

--- a/snapshot_iterator.go
+++ b/snapshot_iterator.go
@@ -61,7 +61,7 @@ type (
 	snapshotIteratorConfig struct {
 		db            *sqlx.DB
 		tableKeys     common.TableKeys
-		fetchSize     int
+		fetchSize     int64
 		startPosition *common.SnapshotPosition
 		database      string
 		tables        []string

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/conduitio-labs/conduit-connector-mysql/common"
@@ -90,4 +91,93 @@ func TestSource_ConsistentSnapshot(t *testing.T) {
 	testutils.ReadAndAssertInsert(ctx, is, sourceIterator, user5)
 	testutils.ReadAndAssertInsert(ctx, is, sourceIterator, user6)
 	testutils.ReadAndAssertDelete(ctx, is, sourceIterator, user4)
+}
+
+func TestSource_MultipleSnapshotFetches(t *testing.T) {
+	ctx := testutils.TestContext(t)
+	is := is.New(t)
+
+	db := testutils.Connection(t)
+
+	userTable.Recreate(is, db)
+
+	// insert 100 users, delete first 20 so that the min primary key code path
+	// is hit
+
+	var inserted []testutils.User
+	for i := 0; i < 100; i++ {
+		user := userTable.Insert(is, db, fmt.Sprint("user", i+1))
+		inserted = append(inserted, user)
+	}
+	toDelete := inserted[:20]
+	inserted = inserted[20:]
+
+	for _, user := range toDelete {
+		userTable.Delete(is, db, user)
+	}
+
+	source := &Source{}
+	err := source.Configure(ctx, config.Config{
+		common.SourceConfigUrl:              testutils.DSN,
+		common.SourceConfigTables:           "users",
+		common.SourceConfigDisableCanalLogs: "true",
+		common.SourceConfigFetchSize:        "10",
+	})
+	is.NoErr(err)
+
+	is.NoErr(source.Open(ctx, nil))
+
+	defer func() { is.NoErr(source.Teardown(ctx)) }()
+
+	sourceIterator := sourceIterator{source}
+
+	for _, user := range inserted {
+		testutils.ReadAndAssertSnapshot(ctx, is, sourceIterator, user)
+	}
+}
+
+func TestSource_EmptyChunkRead(t *testing.T) {
+	ctx := testutils.TestContext(t)
+	is := is.New(t)
+
+	db := testutils.Connection(t)
+
+	userTable.Recreate(is, db)
+
+	var inserted []testutils.User
+	for i := 0; i < 100; i++ {
+		user := userTable.Insert(is, db, fmt.Sprint("user", i+1))
+		inserted = append(inserted, user)
+	}
+
+	firstPart := inserted[:20]
+	secondPart := inserted[40:]
+	toDelete := inserted[20:40]
+
+	var expected []testutils.User
+	expected = append(expected, firstPart...)
+	expected = append(expected, secondPart...)
+
+	for _, user := range toDelete {
+		userTable.Delete(is, db, user)
+	}
+
+	source := &Source{}
+	err := source.Configure(ctx, config.Config{
+		common.SourceConfigUrl:              testutils.DSN,
+		common.SourceConfigTables:           "users",
+		common.SourceConfigDisableCanalLogs: "true",
+		common.SourceConfigFetchSize:        "10",
+	})
+	is.NoErr(err)
+
+	is.NoErr(source.Open(ctx, nil))
+
+	defer func() { is.NoErr(source.Teardown(ctx)) }()
+
+	sourceIterator := sourceIterator{source}
+
+	for _, user := range expected {
+		testutils.ReadAndAssertSnapshot(ctx, is, sourceIterator, user)
+	}
 }

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -61,7 +61,10 @@ func Connection(t *testing.T) *sqlx.DB {
 }
 
 func TestContext(t *testing.T) context.Context {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
+	writer := zerolog.NewTestWriter(t)
+	logger := zerolog.New(writer).
+		Level(zerolog.InfoLevel)
+		// Level(zerolog.TraceLevel)
 	return logger.WithContext(context.Background())
 }
 


### PR DESCRIPTION
### Description

Prevents pipeline crash when cdc iterator emits an uint64. Avro doesn't support uint64. I've tested locally support for uint8, 16 and 32, and the pipeline did not crash, only when emitting uint64 columns in the structured data.

Fixes #50 

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [ ] I have written unit tests (I believe this is external to the connector itself. Could it be handled by the avro encoding middleware instead?)
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.