### PR TITLE
Fixes naïve snapshot iteration

### DIFF
--- a/cdc_iterator_integration_test.go
+++ b/cdc_iterator_integration_test.go
@@ -81,14 +81,14 @@ func TestCDCIterator_InsertAction(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	iterator, teardown := testCdcIterator(ctx, t, is)
 	defer teardown()
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	testutils.ReadAndAssertCreate(ctx, is, iterator, user1)
 	testutils.ReadAndAssertCreate(ctx, is, iterator, user2)
@@ -101,18 +101,18 @@ func TestCDCIterator_DeleteAction(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	iterator, teardown := testCdcIterator(ctx, t, is)
 	defer teardown()
 
-	userTable.Delete(is, db, user1)
-	userTable.Delete(is, db, user2)
-	userTable.Delete(is, db, user3)
+	testutils.DeleteUser(is, db, user1)
+	testutils.DeleteUser(is, db, user2)
+	testutils.DeleteUser(is, db, user3)
 
 	testutils.ReadAndAssertDelete(ctx, is, iterator, user1)
 	testutils.ReadAndAssertDelete(ctx, is, iterator, user2)
@@ -125,18 +125,18 @@ func TestCDCIterator_UpdateAction(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	iterator, teardown := testCdcIterator(ctx, t, is)
 	defer teardown()
 
-	user1Updated := userTable.Update(is, db, user1.Update())
-	user2Updated := userTable.Update(is, db, user2.Update())
-	user3Updated := userTable.Update(is, db, user3.Update())
+	user1Updated := testutils.UpdateUser(is, db, user1.Update())
+	user2Updated := testutils.UpdateUser(is, db, user2.Update())
+	user3Updated := testutils.UpdateUser(is, db, user3.Update())
 
 	testutils.ReadAndAssertUpdate(ctx, is, iterator, user1, user1Updated)
 	testutils.ReadAndAssertUpdate(ctx, is, iterator, user2, user2Updated)
@@ -149,7 +149,7 @@ func TestCDCIterator_RestartOnPosition(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	// start the iterator at the beginning
 
@@ -157,10 +157,10 @@ func TestCDCIterator_RestartOnPosition(t *testing.T) {
 
 	// and trigger some insert actions
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
-	user4 := userTable.Insert(is, db, "user4")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
+	user4 := testutils.InsertUser(is, db, 4)
 
 	var latestPosition opencdc.Position
 
@@ -177,7 +177,7 @@ func TestCDCIterator_RestartOnPosition(t *testing.T) {
 	iterator, teardown = testCdcIteratorAtPosition(ctx, t, is, latestPosition)
 	defer teardown()
 
-	user5 := userTable.Insert(is, db, "user5")
+	user5 := testutils.InsertUser(is, db, 5)
 
 	testutils.ReadAndAssertCreate(ctx, is, iterator, user3)
 	testutils.ReadAndAssertCreate(ctx, is, iterator, user4)

--- a/combined_iterator_integration_test.go
+++ b/combined_iterator_integration_test.go
@@ -50,11 +50,11 @@ func TestCombinedIterator_SnapshotAndCDC(t *testing.T) {
 	is := is.New(t)
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	iterator, cleanup := testCombinedIterator(ctx, t, is)
 	defer cleanup()
@@ -63,9 +63,9 @@ func TestCombinedIterator_SnapshotAndCDC(t *testing.T) {
 	// Theoretically it should not matter, as we get the position at the start.
 	time.Sleep(time.Second)
 
-	user1Updated := userTable.Update(is, db, user1.Update())
-	user2Updated := userTable.Update(is, db, user2.Update())
-	user3Updated := userTable.Update(is, db, user3.Update())
+	user1Updated := testutils.UpdateUser(is, db, user1.Update())
+	user2Updated := testutils.UpdateUser(is, db, user2.Update())
+	user3Updated := testutils.UpdateUser(is, db, user3.Update())
 
 	testutils.ReadAndAssertSnapshot(ctx, is, iterator, user1)
 	testutils.ReadAndAssertSnapshot(ctx, is, iterator, user2)

--- a/common/position.go
+++ b/common/position.go
@@ -73,8 +73,8 @@ func ParseSDKPosition(p opencdc.Position) (Position, error) {
 type SnapshotPositions map[string]TablePosition
 
 type TablePosition struct {
-	LastRead    int64 `json:"last_read"`
-	SnapshotEnd int64 `json:"snapshot_end"`
+	LastRead    uint64 `json:"last_read"`
+	SnapshotEnd uint64 `json:"snapshot_end"`
 }
 
 type CdcPosition struct {

--- a/common/utils.go
+++ b/common/utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/rs/zerolog"
 	"github.com/siddontang/go-log/log"
+	"golang.org/x/exp/constraints"
 )
 
 func FormatValue(val any) any {
@@ -50,6 +51,39 @@ func FormatValue(val any) any {
 		return val
 	default:
 		return val
+	}
+}
+
+func intToUint64[T constraints.Integer](val T) (uint64, error) {
+	v := int64(val)
+	if v < 0 {
+		return 0, fmt.Errorf("primary key %v of type %T is invalid", val, val)
+	}
+	return uint64(v), nil
+}
+
+func ConvertPrimaryKey(val any) (uint64, error) {
+	switch v := val.(type) {
+	case int:
+		return intToUint64(v)
+	case int8:
+		return intToUint64(v)
+	case int16:
+		return intToUint64(v)
+	case int32:
+		return intToUint64(v)
+	case int64:
+		return intToUint64(v)
+	case uint8:
+		return intToUint64(v)
+	case uint16:
+		return intToUint64(v)
+	case uint32:
+		return intToUint64(v)
+	case uint64:
+		return v, nil
+	default:
+		return 0, fmt.Errorf("unsupported primary key type %T", v)
 	}
 }
 

--- a/destination_integration_test.go
+++ b/destination_integration_test.go
@@ -46,11 +46,11 @@ func TestDestination_OperationSnapshot(t *testing.T) {
 	is := is.New(t)
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	dest, cleanDest := testDestination(ctx, is)
 	defer cleanDest()
@@ -63,15 +63,15 @@ func TestDestination_OperationSnapshot(t *testing.T) {
 	rec3 := testutils.ReadAndAssertSnapshot(ctx, is, src, user3)
 
 	// clean table to assert snapshots were written
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	written, err := dest.Write(ctx, []opencdc.Record{rec1, rec2, rec3})
 	is.NoErr(err)
 	is.Equal(written, 3)
 
-	insertedUser1 := userTable.Get(is, db, user1.ID)
-	insertedUser2 := userTable.Get(is, db, user2.ID)
-	insertedUser3 := userTable.Get(is, db, user3.ID)
+	insertedUser1 := testutils.GetUser(is, db, user1.ID)
+	insertedUser2 := testutils.GetUser(is, db, user2.ID)
+	insertedUser3 := testutils.GetUser(is, db, user3.ID)
 
 	is.Equal("", cmp.Diff(user1, insertedUser1))
 	is.Equal("", cmp.Diff(user2, insertedUser2))
@@ -83,31 +83,31 @@ func TestDestination_OperationCreate(t *testing.T) {
 	is := is.New(t)
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 	dest, cleanDest := testDestination(ctx, is)
 	defer cleanDest()
 
 	src, cleanSrc := testSource(ctx, is)
 	defer cleanSrc()
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	rec1 := testutils.ReadAndAssertCreate(ctx, is, src, user1)
 	rec2 := testutils.ReadAndAssertCreate(ctx, is, src, user2)
 	rec3 := testutils.ReadAndAssertCreate(ctx, is, src, user3)
 
 	// clean table to assert snapshots were written
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	written, err := dest.Write(ctx, []opencdc.Record{rec1, rec2, rec3})
 	is.NoErr(err)
 	is.Equal(written, 3)
 
-	insertedUser1 := userTable.Get(is, db, user1.ID)
-	insertedUser2 := userTable.Get(is, db, user2.ID)
-	insertedUser3 := userTable.Get(is, db, user3.ID)
+	insertedUser1 := testutils.GetUser(is, db, user1.ID)
+	insertedUser2 := testutils.GetUser(is, db, user2.ID)
+	insertedUser3 := testutils.GetUser(is, db, user3.ID)
 
 	is.Equal("", cmp.Diff(user1, insertedUser1))
 	is.Equal("", cmp.Diff(user2, insertedUser2))
@@ -119,11 +119,11 @@ func TestDestination_OperationUpdate(t *testing.T) {
 	is := is.New(t)
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	dest, cleanDest := testDestination(ctx, is)
 	defer cleanDest()
@@ -131,9 +131,9 @@ func TestDestination_OperationUpdate(t *testing.T) {
 	src, cleanSrc := testSource(ctx, is)
 	defer cleanSrc()
 
-	user1Updated := userTable.Update(is, db, user1.Update())
-	user2Updated := userTable.Update(is, db, user2.Update())
-	user3Updated := userTable.Update(is, db, user3.Update())
+	user1Updated := testutils.UpdateUser(is, db, user1.Update())
+	user2Updated := testutils.UpdateUser(is, db, user2.Update())
+	user3Updated := testutils.UpdateUser(is, db, user3.Update())
 
 	// discard snapshots, we want the updates only
 	testutils.ReadAndAssertSnapshot(ctx, is, src, user1)
@@ -145,15 +145,15 @@ func TestDestination_OperationUpdate(t *testing.T) {
 	rec3 := testutils.ReadAndAssertUpdate(ctx, is, src, user3, user3Updated)
 
 	// clean table to assert snapshots were written
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	written, err := dest.Write(ctx, []opencdc.Record{rec1, rec2, rec3})
 	is.NoErr(err)
 	is.Equal(written, 3)
 
-	insertedUser1 := userTable.Get(is, db, user1.ID)
-	insertedUser2 := userTable.Get(is, db, user2.ID)
-	insertedUser3 := userTable.Get(is, db, user3.ID)
+	insertedUser1 := testutils.GetUser(is, db, user1.ID)
+	insertedUser2 := testutils.GetUser(is, db, user2.ID)
+	insertedUser3 := testutils.GetUser(is, db, user3.ID)
 
 	is.Equal("", cmp.Diff(user1Updated, insertedUser1))
 	is.Equal("", cmp.Diff(user2Updated, insertedUser2))
@@ -165,11 +165,11 @@ func TestDestination_OperationDelete(t *testing.T) {
 	is := is.New(t)
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
-	user1 := userTable.Insert(is, db, "user1")
-	user2 := userTable.Insert(is, db, "user2")
-	user3 := userTable.Insert(is, db, "user3")
+	user1 := testutils.InsertUser(is, db, 1)
+	user2 := testutils.InsertUser(is, db, 2)
+	user3 := testutils.InsertUser(is, db, 3)
 
 	dest, cleanDest := testDestination(ctx, is)
 	defer cleanDest()
@@ -177,9 +177,9 @@ func TestDestination_OperationDelete(t *testing.T) {
 	src, cleanSrc := testSource(ctx, is)
 	defer cleanSrc()
 
-	userTable.Delete(is, db, user1)
-	userTable.Delete(is, db, user2)
-	userTable.Delete(is, db, user3)
+	testutils.DeleteUser(is, db, user1)
+	testutils.DeleteUser(is, db, user2)
+	testutils.DeleteUser(is, db, user3)
 
 	// discard snapshots, we want the deletes only
 	testutils.ReadAndAssertSnapshot(ctx, is, src, user1)
@@ -191,17 +191,17 @@ func TestDestination_OperationDelete(t *testing.T) {
 	rec3 := testutils.ReadAndAssertDelete(ctx, is, src, user3)
 
 	// reset autoincrement primary key
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	// insert users back to assert deletes where done
-	userTable.Insert(is, db, "user1")
-	userTable.Insert(is, db, "user2")
-	userTable.Insert(is, db, "user3")
+	testutils.InsertUser(is, db, 1)
+	testutils.InsertUser(is, db, 2)
+	testutils.InsertUser(is, db, 3)
 
 	written, err := dest.Write(ctx, []opencdc.Record{rec1, rec2, rec3})
 	is.NoErr(err)
 	is.Equal(written, 3)
 
-	total := userTable.CountUsers(is, db)
+	total := testutils.CountUsers(is, db)
 	is.Equal(total, 0)
 }

--- a/fetch_worker.go
+++ b/fetch_worker.go
@@ -53,7 +53,7 @@ func newFetchWorker(db *sqlx.DB, data chan fetchData, config fetchWorkerConfig) 
 
 func (w *fetchWorker) fetchStartEnd(ctx context.Context) (err error) {
 	lastRead := w.config.lastPosition.Snapshots[w.config.table].LastRead
-	minVal, maxVal, err := w.getMinMaxValue(ctx)
+	minVal, maxVal, err := w.getMinMaxValues(ctx)
 	if err != nil {
 		return err
 	}
@@ -145,8 +145,8 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 	return nil
 }
 
-// getMinMaxValue fetches the maximum value of the primary key from the table.
-func (w *fetchWorker) getMinMaxValue(ctx context.Context) (minVal, maxVal uint64, err error) {
+// getMinMaxValues fetches the maximum value of the primary key from the table.
+func (w *fetchWorker) getMinMaxValues(ctx context.Context) (minVal, maxVal uint64, err error) {
 	var minmax struct {
 		MinValue *uint64 `db:"min_value"`
 		MaxValue *uint64 `db:"max_value"`

--- a/fetch_worker.go
+++ b/fetch_worker.go
@@ -100,8 +100,7 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 		chunkEnd := chunkStart + w.config.fetchSize
 		sdk.Logger(ctx).Info().
 			Uint64("chunk start", chunkStart).
-			// the where clause is exclusive at the end
-			Uint64("chunk end", chunkEnd-1).
+			Uint64("chunk end", chunkEnd).
 			Msg("fetching chunk")
 		rows, err := w.selectRowsChunk(ctx, tx, chunkStart, chunkEnd)
 		if err != nil {

--- a/fetch_worker.go
+++ b/fetch_worker.go
@@ -59,7 +59,7 @@ func (w *fetchWorker) fetchStartEnd(ctx context.Context) (err error) {
 	}
 
 	if lastRead > minVal {
-		// last read takes preference, as previous records where already fetched
+		// last read takes preference, as previous records where already fetched.
 		w.start = lastRead
 	} else {
 		w.start = minVal
@@ -125,7 +125,9 @@ func (w *fetchWorker) run(ctx context.Context) (err error) {
 			}
 
 			position := common.TablePosition{
-				LastRead:    lastRead,
+				// plus 1 so that we start reading from the correct place, otherwise
+				// we would read the same record twice on multiple snapshots
+				LastRead:    lastRead + 1,
 				SnapshotEnd: w.end,
 			}
 			data, err := w.buildFetchData(row, position)

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
-	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
+	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6
 	golang.org/x/exp/typeparams v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.30.0 // indirect

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -112,7 +112,7 @@ func TestSnapshotIterator_EmptyTable(t *testing.T) {
 }
 
 func TestSnapshotIterator_WithData(t *testing.T) {
-	ctx := testutils.TestContextNoTraceLog(t)
+	ctx := testutils.TestContext(t)
 
 	is := is.New(t)
 
@@ -140,7 +140,7 @@ func TestSnapshotIterator_WithData(t *testing.T) {
 }
 
 func TestSnapshotIterator_SmallFetchSize(t *testing.T) {
-	ctx := testutils.TestContextNoTraceLog(t)
+	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
 	db := testutils.Connection(t)
@@ -167,14 +167,14 @@ func TestSnapshotIterator_SmallFetchSize(t *testing.T) {
 }
 
 func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
-	ctx := testutils.TestContextNoTraceLog(t)
+	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
 	db := testutils.Connection(t)
 
 	userTable.Recreate(is, db)
 	var users []testutils.User
-	for i := 0; i < 100; i++ {
+	for i := 1; i <= 100; i++ {
 		user := userTable.Insert(is, db, fmt.Sprintf("user-%v", i))
 		users = append(users, user)
 	}
@@ -186,8 +186,7 @@ func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
 	{
 		it, cleanup := testSnapshotIterator(ctx, t, is)
 
-		var last opencdc.Record
-		for i := 0; i < 10; i++ {
+		for i := 1; i <= 10; i++ {
 			rec, err := it.Next(ctx)
 			if errors.Is(err, ErrSnapshotIteratorDone) {
 				err = it.Ack(ctx, rec.Position)
@@ -200,10 +199,8 @@ func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
 
 			err = it.Ack(ctx, rec.Position)
 			is.NoErr(err)
-			last = rec
+			breakPosition = rec.Position
 		}
-
-		breakPosition = last.Position
 
 		// not deferring the call so that logs are easier to understand
 		cleanup()

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -118,7 +118,7 @@ func TestSnapshotIterator_WithData(t *testing.T) {
 	testutils.RecreateUsersTable(is, db)
 
 	var users []testutils.User
-	for i := 0; i < 100; i++ {
+	for i := 1; i <= 100; i++ {
 		user := testutils.InsertUser(is, db, i)
 		users = append(users, user)
 	}
@@ -128,8 +128,8 @@ func TestSnapshotIterator_WithData(t *testing.T) {
 	iterator, cleanup := testSnapshotIterator(ctx, t, is)
 	defer cleanup()
 
-	for i := 0; i < 100; i++ {
-		testutils.ReadAndAssertSnapshot(ctx, is, iterator, users[i])
+	for i := 1; i <= 100; i++ {
+		testutils.ReadAndAssertSnapshot(ctx, is, iterator, users[i-1])
 	}
 
 	_, err := iterator.Next(ctx)
@@ -145,7 +145,7 @@ func TestSnapshotIterator_SmallFetchSize(t *testing.T) {
 	testutils.RecreateUsersTable(is, db)
 
 	var users []testutils.User
-	for i := 0; i < 100; i++ {
+	for i := 1; i <= 100; i++ {
 		user := testutils.InsertUser(is, db, i)
 		users = append(users, user)
 	}
@@ -155,8 +155,8 @@ func TestSnapshotIterator_SmallFetchSize(t *testing.T) {
 	iterator, cleanup := testSnapshotIterator(ctx, t, is)
 	defer cleanup()
 
-	for i := 0; i < 100; i++ {
-		testutils.ReadAndAssertSnapshot(ctx, is, iterator, users[i])
+	for i := 1; i <= 100; i++ {
+		testutils.ReadAndAssertSnapshot(ctx, is, iterator, users[i-1])
 	}
 
 	_, err := iterator.Next(ctx)

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -185,8 +185,8 @@ func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
 	var breakPosition opencdc.Position
 	{
 		it, cleanup := testSnapshotIterator(ctx, t, is)
-		defer cleanup()
 
+		var last opencdc.Record
 		for i := 0; i < 10; i++ {
 			rec, err := it.Next(ctx)
 			if errors.Is(err, ErrSnapshotIteratorDone) {
@@ -200,9 +200,13 @@ func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
 
 			err = it.Ack(ctx, rec.Position)
 			is.NoErr(err)
+			last = rec
 		}
 
-		breakPosition = recs[len(recs)-1].Position
+		breakPosition = last.Position
+
+		// not deferring the call so that logs are easier to understand
+		cleanup()
 	}
 
 	// read the remaining 90 records

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -17,7 +17,6 @@ package mysql
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/conduitio-labs/conduit-connector-mysql/common"
@@ -26,8 +25,6 @@ import (
 	"github.com/matryer/is"
 	"go.uber.org/goleak"
 )
-
-var userTable testutils.UsersTable
 
 func testSnapshotIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterator, func()) {
 	db := testutils.Connection(t)
@@ -98,7 +95,7 @@ func TestSnapshotIterator_EmptyTable(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -118,11 +115,11 @@ func TestSnapshotIterator_WithData(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	var users []testutils.User
 	for i := 0; i < 100; i++ {
-		user := userTable.Insert(is, db, fmt.Sprintf("user-%v", i))
+		user := testutils.InsertUser(is, db, i)
 		users = append(users, user)
 	}
 
@@ -145,11 +142,11 @@ func TestSnapshotIterator_SmallFetchSize(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 
 	var users []testutils.User
 	for i := 0; i < 100; i++ {
-		user := userTable.Insert(is, db, fmt.Sprintf("user-%v", i))
+		user := testutils.InsertUser(is, db, i)
 		users = append(users, user)
 	}
 
@@ -172,10 +169,10 @@ func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	userTable.Recreate(is, db)
+	testutils.RecreateUsersTable(is, db)
 	var users []testutils.User
 	for i := 1; i <= 100; i++ {
-		user := userTable.Insert(is, db, fmt.Sprintf("user-%v", i))
+		user := testutils.InsertUser(is, db, i)
 		users = append(users, user)
 	}
 

--- a/source.go
+++ b/source.go
@@ -147,6 +147,7 @@ func getPrimaryKey(db *sqlx.DB, database, table string) (string, error) {
 			constraint_name = 'PRIMARY'
 			AND table_schema = ?
 			AND table_name = ?
+			ORDER BY ORDINAL_POSITION DESC
 	`, database, table)
 
 	if err := row.StructScan(&primaryKey); err != nil {

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -102,7 +102,7 @@ func TestSource_ConsistentSnapshot(t *testing.T) {
 	testutils.ReadAndAssertDelete(ctx, is, source, user4)
 }
 
-func TestSource_MultipleSnapshotFetches(t *testing.T) {
+func TestSource_NonZeroSnapshotStart(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
@@ -110,19 +110,14 @@ func TestSource_MultipleSnapshotFetches(t *testing.T) {
 
 	userTable.Recreate(is, db)
 
-	// insert 100 users, delete first 20 so that the min primary key code path
-	// is hit
+	// Insert 80 users starting from the 20th so that the starting gotten row is
+	// more than 0. This way we ensure a more realistic dataset, where first
+	// rows don't start from 0.
 
 	var inserted []testutils.User
-	for i := 0; i < 100; i++ {
+	for i := 20; i < 100; i++ {
 		user := userTable.Insert(is, db, fmt.Sprint("user", i+1))
 		inserted = append(inserted, user)
-	}
-	toDelete := inserted[:20]
-	inserted = inserted[20:]
-
-	for _, user := range toDelete {
-		userTable.Delete(is, db, user)
 	}
 
 	source, teardown := testSourceWithFetchSize(ctx, is, "10")

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -110,9 +110,9 @@ func TestSource_NonZeroSnapshotStart(t *testing.T) {
 
 	userTable.Recreate(is, db)
 
-	// Insert 80 users starting from the 20th so that the starting gotten row is
-	// more than 0. This way we ensure a more realistic dataset, where first
-	// rows don't start from 0.
+	// Insert 80 users starting from the 20th so that the starting row's primary key
+	// is greater than 0. This ensures a more realistic dataset where
+	// the first rows don't start at 0.
 
 	var inserted []testutils.User
 	for i := 20; i < 100; i++ {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -17,8 +17,9 @@ services:
       - main
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
+      interval: 1s
       timeout: 20s
-      retries: 10
+      retries: 30
 
   # Adminer is a web-based SQL management tool. Useful on development
   adminer:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -17,9 +17,8 @@ services:
       - main
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
-      interval: 1s
       timeout: 20s
-      retries: 30
+      retries: 10
 
   # Adminer is a web-based SQL management tool. Useful on development
   adminer:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -12,13 +12,14 @@ services:
       MYSQL_PASSWORD: meroxapass
       MYSQL_ROOT_PASSWORD: meroxaadmin
     ports:
-      - "3306:3306"
+      - '3306:3306'
     networks:
       - main
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
+      interval: 1s
       timeout: 20s
-      retries: 10
+      retries: 30
 
   # Adminer is a web-based SQL management tool. Useful on development
   adminer:

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -52,12 +52,6 @@ func TestContext(t *testing.T) context.Context {
 	return logger.WithContext(context.Background())
 }
 
-func TestContextNoTraceLog(t *testing.T) context.Context {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
-
-	return logger.Level(zerolog.DebugLevel).WithContext(context.Background())
-}
-
 var TableKeys = common.TableKeys{
 	"users": "id",
 }

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -48,8 +48,7 @@ func Connection(t *testing.T) *sqlx.DB {
 
 func TestContext(t *testing.T) context.Context {
 	writer := zerolog.NewTestWriter(t)
-	// logger := zerolog.New(writer).Level(zerolog.InfoLevel)
-	logger := zerolog.New(writer).Level(zerolog.TraceLevel)
+	logger := zerolog.New(writer).Level(zerolog.InfoLevel)
 	return logger.WithContext(context.Background())
 }
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -169,8 +169,8 @@ func ReadAndAssertCreate(
 
 	assertMetadata(is, rec.Metadata)
 
-	IsDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
-	IsDataEqual(is, rec.Payload.After, user.ToStructuredData())
+	isDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
+	isDataEqual(is, rec.Payload.After, user.ToStructuredData())
 
 	return rec
 }
@@ -188,11 +188,11 @@ func ReadAndAssertUpdate(
 
 	assertMetadata(is, rec.Metadata)
 
-	IsDataEqual(is, rec.Key, opencdc.StructuredData{"id": prev.ID})
-	IsDataEqual(is, rec.Key, opencdc.StructuredData{"id": next.ID})
+	isDataEqual(is, rec.Key, opencdc.StructuredData{"id": prev.ID})
+	isDataEqual(is, rec.Key, opencdc.StructuredData{"id": next.ID})
 
-	IsDataEqual(is, rec.Payload.Before, prev.ToStructuredData())
-	IsDataEqual(is, rec.Payload.After, next.ToStructuredData())
+	isDataEqual(is, rec.Payload.Before, prev.ToStructuredData())
+	isDataEqual(is, rec.Payload.After, next.ToStructuredData())
 
 	return rec
 }
@@ -211,12 +211,12 @@ func ReadAndAssertDelete(
 
 	assertMetadata(is, rec.Metadata)
 
-	IsDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
+	isDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
 
 	return rec
 }
 
-func IsDataEqual(is *is.I, a, b opencdc.Data) {
+func isDataEqual(is *is.I, a, b opencdc.Data) {
 	is.Helper()
 	is.Equal("", cmp.Diff(a, b))
 }
@@ -234,8 +234,8 @@ func ReadAndAssertSnapshot(
 
 	assertMetadata(is, rec.Metadata)
 
-	IsDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
-	IsDataEqual(is, rec.Payload.After, user.ToStructuredData())
+	isDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
+	isDataEqual(is, rec.Payload.After, user.ToStructuredData())
 
 	return rec
 }
@@ -246,8 +246,8 @@ func AssertUserSnapshot(is *is.I, user User, rec opencdc.Record) {
 
 	assertMetadata(is, rec.Metadata)
 
-	IsDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
-	IsDataEqual(is, rec.Payload.After, user.ToStructuredData())
+	isDataEqual(is, rec.Key, opencdc.StructuredData{"id": user.ID})
+	isDataEqual(is, rec.Payload.After, user.ToStructuredData())
 }
 
 func assertMetadata(is *is.I, metadata opencdc.Metadata) {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -47,7 +47,10 @@ func Connection(t *testing.T) *sqlx.DB {
 }
 
 func TestContext(t *testing.T) context.Context {
-	logger := zerolog.New(zerolog.NewTestWriter(t))
+	writer := zerolog.NewTestWriter(t)
+	logger := zerolog.New(writer).
+		Level(zerolog.InfoLevel)
+		// Level(zerolog.TraceLevel)
 	return logger.WithContext(context.Background())
 }
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -48,9 +48,7 @@ func Connection(t *testing.T) *sqlx.DB {
 
 func TestContext(t *testing.T) context.Context {
 	writer := zerolog.NewTestWriter(t)
-	logger := zerolog.New(writer).
-		Level(zerolog.InfoLevel)
-		// Level(zerolog.TraceLevel)
+	logger := zerolog.New(writer).Level(zerolog.InfoLevel)
 	return logger.WithContext(context.Background())
 }
 


### PR DESCRIPTION
### Description

Fixes the naïve snapshot iteration implemented before, and adds 2 tests to enforce the correct iteration.
Fixes #52 

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.