### PR TITLE
migrate tests to gorm

### DIFF
--- a/cdc_iterator_integration_test.go
+++ b/cdc_iterator_integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func testCdcIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterator, func()) {
-	db := testutils.Connection(t)
+	db := testutils.Connection(t).Conn()
 
 	config, err := mysql.ParseDSN(testutils.DSN)
 	is.NoErr(err)
@@ -50,7 +50,7 @@ func testCdcIteratorAtPosition(
 	ctx context.Context, t *testing.T, is *is.I,
 	sdkPos opencdc.Position,
 ) (common.Iterator, func()) {
-	db := testutils.Connection(t)
+	db := testutils.Connection(t).Conn()
 
 	config, err := mysql.ParseDSN(testutils.DSN)
 	is.NoErr(err)

--- a/cdc_iterator_integration_test.go
+++ b/cdc_iterator_integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func testCdcIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterator, func()) {
-	db := testutils.Connection(t).Conn()
+	db := testutils.NewDB(t).SqlxDB
 
 	config, err := mysql.ParseDSN(testutils.DSN)
 	is.NoErr(err)
@@ -50,7 +50,7 @@ func testCdcIteratorAtPosition(
 	ctx context.Context, t *testing.T, is *is.I,
 	sdkPos opencdc.Position,
 ) (common.Iterator, func()) {
-	db := testutils.Connection(t).Conn()
+	db := testutils.NewDB(t).SqlxDB
 
 	config, err := mysql.ParseDSN(testutils.DSN)
 	is.NoErr(err)
@@ -78,7 +78,7 @@ func TestCDCIterator_InsertAction(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -98,7 +98,7 @@ func TestCDCIterator_DeleteAction(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -122,7 +122,7 @@ func TestCDCIterator_UpdateAction(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -146,7 +146,7 @@ func TestCDCIterator_RestartOnPosition(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 

--- a/combined_iterator_integration_test.go
+++ b/combined_iterator_integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func testCombinedIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterator, func()) {
-	db := testutils.Connection(t)
+	db := testutils.Connection(t).Conn()
 
 	config, err := mysql.ParseDSN(testutils.DSN)
 	is.NoErr(err)

--- a/combined_iterator_integration_test.go
+++ b/combined_iterator_integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func testCombinedIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterator, func()) {
-	db := testutils.Connection(t).Conn()
+	db := testutils.NewDB(t).SqlxDB
 
 	config, err := mysql.ParseDSN(testutils.DSN)
 	is.NoErr(err)
@@ -48,7 +48,7 @@ func testCombinedIterator(ctx context.Context, t *testing.T, is *is.I) (common.I
 func TestCombinedIterator_SnapshotAndCDC(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 

--- a/destination_integration_test.go
+++ b/destination_integration_test.go
@@ -44,7 +44,7 @@ func testDestination(ctx context.Context, is *is.I) (sdk.Destination, func()) {
 func TestDestination_OperationSnapshot(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -81,7 +81,7 @@ func TestDestination_OperationSnapshot(t *testing.T) {
 func TestDestination_OperationCreate(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 	dest, cleanDest := testDestination(ctx, is)
@@ -117,7 +117,7 @@ func TestDestination_OperationCreate(t *testing.T) {
 func TestDestination_OperationUpdate(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -163,7 +163,7 @@ func TestDestination_OperationUpdate(t *testing.T) {
 func TestDestination_OperationDelete(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ import (
 )
 
 func testSnapshotIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterator, func()) {
-	db := testutils.Connection(t)
+	db := testutils.Connection(t).Conn()
 
 	serverID, err := common.GetServerID(ctx, db)
 	is.NoErr(err)
@@ -58,7 +59,7 @@ func testSnapshotIteratorAtPosition(
 ) (common.Iterator, func()) {
 	db := testutils.Connection(t)
 
-	serverID, err := common.GetServerID(ctx, db)
+	serverID, err := common.GetServerID(ctx, db.Conn())
 	is.NoErr(err)
 
 	pos, err := common.ParseSDKPosition(sdkPos)
@@ -68,7 +69,7 @@ func testSnapshotIteratorAtPosition(
 
 	iterator, err := newSnapshotIterator(snapshotIteratorConfig{
 		tableSortColumns: testutils.TableSortCols,
-		db:               db,
+		db:               db.Conn(),
 		startPosition:    pos.SnapshotPosition,
 		database:         "meroxadb",
 		tables:           []string{"users"},
@@ -80,7 +81,7 @@ func testSnapshotIteratorAtPosition(
 	iterator.start(ctx)
 
 	return iterator, func() {
-		is.NoErr(db.Close())
+		is.NoErr(db.Conn().Close())
 		is.NoErr(iterator.Teardown(ctx))
 	}
 }
@@ -200,62 +201,49 @@ func TestSnapshotIterator_CustomTableKeys(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	var err error
+	type CompositeWithAutoInc struct {
+		ID       int    `gorm:"primaryKey;autoIncrement"`
+		TenantID string `gorm:"size:50"`
+		Data     string `gorm:"size:100"`
+	}
 
-	_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS composite_with_auto_inc;")
-	is.NoErr(err)
-	_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS ulid_pk;")
-	is.NoErr(err)
-	_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS timestamp_ordered;")
-	is.NoErr(err)
+	type UlidPk struct {
+		ID   string `gorm:"primaryKey;size:26"`
+		Data string `gorm:"size:100"`
+	}
 
-	_, err = db.ExecContext(ctx, `
-		CREATE TABLE composite_with_auto_inc (
-			id INT AUTO_INCREMENT PRIMARY KEY,
-			tenant_id VARCHAR(50),
-			data VARCHAR(100),
-			UNIQUE KEY unique_tenant_id (tenant_id, id));`)
-	is.NoErr(err)
+	type TimestampOrdered struct {
+		CreatedAt time.Time `gorm:"index:idx_created_at"`
+		ID        string    `gorm:"size:50;uniqueIndex:unique_record"`
+		Data      string    `gorm:"size:100"`
+	}
 
-	compositeWithAutoIncData := []string{"record 1", "record 2", "record 3"}
-	_, err = db.ExecContext(ctx, fmt.Sprint(`
-		INSERT INTO composite_with_auto_inc (tenant_id, data) VALUES 
-			('tenant1', '`, compositeWithAutoIncData[0], `'),
-			('tenant2', '`, compositeWithAutoIncData[1], `'),
-			('tenant3', '`, compositeWithAutoIncData[2], `');`))
-	is.NoErr(err)
+	is.NoErr(db.Migrator().DropTable(&CompositeWithAutoInc{}))
+	is.NoErr(db.Migrator().DropTable(&UlidPk{}))
+	is.NoErr(db.Migrator().DropTable(&TimestampOrdered{}))
 
-	_, err = db.ExecContext(ctx, `
-		CREATE TABLE ulid_pk (
-			id CHAR(26) PRIMARY KEY,
-			data VARCHAR(100));`)
-	is.NoErr(err)
+	is.NoErr(db.AutoMigrate(&CompositeWithAutoInc{}, &UlidPk{}, &TimestampOrdered{}))
 
-	ulidPkData := []string{"ULID record 1", "ULID record 2"}
-	_, err = db.ExecContext(ctx, fmt.Sprint(`
-		INSERT INTO ulid_pk (id, data) VALUES
-			('01F8MECHZX3TBDSZ7XRADM79XE', '`, ulidPkData[0], `'),
-			('01F8MECHZX3TBDSZ7XRADM79XF', '`, ulidPkData[1], `');`))
-	is.NoErr(err)
+	compositeWithAutoIncData := []CompositeWithAutoInc{
+		{TenantID: "tenant1", Data: "record 1"},
+		{TenantID: "tenant2", Data: "record 2"},
+		{TenantID: "tenant3", Data: "record 3"},
+	}
+	is.NoErr(db.Create(&compositeWithAutoIncData).Error)
 
-	_, err = db.ExecContext(ctx, `
-		CREATE TABLE timestamp_ordered (
-			created_at TIMESTAMP(6),
-			id VARCHAR(50),
-			data VARCHAR(100),
-			UNIQUE KEY unique_record (id),
-			KEY idx_created_at (created_at));`)
-	is.NoErr(err)
+	ulidPkData := []UlidPk{
+		{ID: "01F8MECHZX3TBDSZ7XRADM79XE", Data: "ULID record 1"},
+		{ID: "01F8MECHZX3TBDSZ7XRADM79XF", Data: "ULID record 2"},
+	}
+	is.NoErr(db.Create(&ulidPkData).Error)
 
-	timestampOrderedData := []string{"Timestamp record 1", "Timestamp record 2"}
-	now := time.Now().Format("2006-01-02 15:04:05.999999")
-	oneSecondAgo := time.Now().Add(-1 * time.Second).Format("2006-01-02 15:04:05.999999")
-	_, err = db.ExecContext(ctx, fmt.Sprint(`
-		INSERT INTO timestamp_ordered (created_at, id, data) VALUES 
-			('`, oneSecondAgo, `', 'rec1', '`, timestampOrderedData[0], `'),
-			('`, now, `',          'rec2', '`, timestampOrderedData[1], `');
-	`))
-	is.NoErr(err)
+	now := time.Now()
+	oneSecondAgo := now.Add(-1 * time.Second)
+	timestampOrderedData := []TimestampOrdered{
+		{CreatedAt: oneSecondAgo, ID: "rec1", Data: "Timestamp record 1"},
+		{CreatedAt: now, ID: "rec2", Data: "Timestamp record 2"},
+	}
+	is.NoErr(db.Create(&timestampOrderedData).Error)
 
 	type testCase struct {
 		tableName    string
@@ -267,21 +255,21 @@ func TestSnapshotIterator_CustomTableKeys(t *testing.T) {
 		{
 			tableName:    "composite_with_auto_inc",
 			sortingCol:   "id",
-			expectedData: compositeWithAutoIncData,
+			expectedData: []string{"record 1", "record 2", "record 3"},
 		},
 		{
 			tableName:    "ulid_pk",
 			sortingCol:   "id",
-			expectedData: ulidPkData,
+			expectedData: []string{"ULID record 1", "ULID record 2"},
 		},
 		{
 			tableName:    "timestamp_ordered",
 			sortingCol:   "created_at",
-			expectedData: timestampOrderedData,
+			expectedData: []string{"Timestamp record 1", "Timestamp record 2"},
 		},
 	} {
 		t.Run(fmt.Sprintf("Test table %s", testCase.tableName), func(t *testing.T) {
-			db := testutils.Connection(t)
+			db := testutils.Connection(t).Conn()
 
 			serverID, err := common.GetServerID(ctx, db)
 			is.NoErr(err)
@@ -326,11 +314,14 @@ func TestSnapshotIterator_CustomTableKeys(t *testing.T) {
 }
 
 func TestSnapshotIterator_DeleteEndWhileSnapshotting(t *testing.T) {
+	// Asserts that the snapshot still works even if data is deleted after getting
+	// the snapshot limits.
+
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
 	db := testutils.Connection(t)
-
+	conn := db.Conn()
 	testutils.RecreateUsersTable(is, db)
 
 	var users []testutils.User
@@ -341,12 +332,12 @@ func TestSnapshotIterator_DeleteEndWhileSnapshotting(t *testing.T) {
 
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	serverID, err := common.GetServerID(ctx, db)
+	serverID, err := common.GetServerID(ctx, conn)
 	is.NoErr(err)
 
 	iterator, err := newSnapshotIterator(snapshotIteratorConfig{
 		tableSortColumns: testutils.TableSortCols,
-		db:               db,
+		db:               conn,
 		database:         "meroxadb",
 		tables:           []string{"users"},
 		serverID:         serverID,
@@ -355,27 +346,26 @@ func TestSnapshotIterator_DeleteEndWhileSnapshotting(t *testing.T) {
 
 	is.NoErr(iterator.setupWorkers(ctx))
 
-	// fetched end of the worker, now we can delete the last record
-	// delete the last record so that fetched worker end isn't found
-	_, err = db.ExecContext(ctx, "DELETE FROM users WHERE id = 100")
-	is.NoErr(err)
+	randomUserIndex := rand.IntN(len(users))
+	is.NoErr(db.Delete(users[randomUserIndex]).Error)
+	users = append(users[:randomUserIndex], users[randomUserIndex+1:]...)
 
 	iterator.start(ctx)
 	defer func() {
-		is.NoErr(db.Close())
+		is.NoErr(conn.Close())
 		is.NoErr(iterator.Teardown(ctx))
 	}()
 
-	for i := 1; i <= 99; i++ {
+	for _, user := range users {
 		rec, err := iterator.Read(ctx)
-		if errors.Is(err, ErrSnapshotIteratorDone) {
-			break
-		}
 		is.NoErr(err)
 		is.NoErr(iterator.Ack(ctx, rec.Position))
 
-		testutils.AssertUserSnapshot(is, users[i-1], rec)
+		testutils.AssertUserSnapshot(is, user, rec)
 	}
+
+	_, err = iterator.Read(ctx)
+	is.True(errors.Is(err, ErrSnapshotIteratorDone))
 }
 
 func TestSnapshotIterator_StringSorting(t *testing.T) {
@@ -387,52 +377,43 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 
 	db := testutils.Connection(t)
 
-	_, err := db.ExecContext(ctx, "DROP TABLE IF EXISTS string_sorting;")
-	is.NoErr(err)
-
-	_, err = db.ExecContext(ctx, `
-		CREATE TABLE string_sorting (
-			id INT AUTO_INCREMENT PRIMARY KEY,
-			str VARCHAR(50));`)
-	is.NoErr(err)
-
 	type Table struct {
-		str string
+		ID  int    `gorm:"primaryKey;autoIncrement"`
+		Str string `gorm:"size:50"`
 	}
 
+	is.NoErr(db.Migrator().DropTable(&Table{}))
+
+	is.NoErr(db.AutoMigrate(&Table{}))
+
 	data := []Table{
-		{"Zebra"},
-		{"apple"},
-		{"BANANA"},
-		{"āpple"},
-		{"_apple"},
-		{"123apple"},
-		{"Apple"},
+		{Str: "Zebra"},
+		{Str: "apple"},
+		{Str: "BANANA"},
+		{Str: "āpple"},
+		{Str: "_apple"},
+		{Str: "123apple"},
+		{Str: "Apple"},
 	}
 
 	sorted := []Table{
-		{"_apple"},
-		{"123apple"},
-		{"apple"},
-		{"āpple"},
-		{"Apple"},
-		{"BANANA"},
-		{"Zebra"},
+		{Str: "_apple"},
+		{Str: "123apple"},
+		{Str: "apple"},
+		{Str: "āpple"},
+		{Str: "Apple"},
+		{Str: "BANANA"},
+		{Str: "Zebra"},
 	}
 
-	for _, data := range data {
-		_, err = db.ExecContext(ctx, fmt.Sprintf(`
-			INSERT INTO string_sorting (str) VALUES ('%s');`,
-			data.str))
-		is.NoErr(err)
-	}
+	is.NoErr(db.Create(&data).Error)
 
-	serverID, err := common.GetServerID(ctx, db)
+	serverID, err := common.GetServerID(ctx, db.Conn())
 	is.NoErr(err)
 
 	iterator, err := newSnapshotIterator(snapshotIteratorConfig{
 		tableSortColumns: map[string]string{"string_sorting": "str"},
-		db:               db,
+		db:               db.Conn(),
 		database:         "meroxadb",
 		tables:           []string{"string_sorting"},
 		serverID:         serverID,
@@ -461,7 +442,7 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 	for i, expectedData := range sorted {
 		actual := recs[i]
 		is.Equal(actual.Operation, opencdc.OperationSnapshot)
-		is.Equal(actual.Payload.After.(opencdc.StructuredData)["str"].(string), expectedData.str)
+		is.Equal(actual.Payload.After.(opencdc.StructuredData)["str"].(string), expectedData.Str)
 	}
 
 	is.NoErr(iterator.Teardown(ctx))

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -253,17 +253,17 @@ func TestSnapshotIterator_CustomTableKeys(t *testing.T) {
 
 	for _, testCase := range []testCase{
 		{
-			tableName:    "composite_with_auto_inc",
+			tableName:    testutils.TableName(is, db, &CompositeWithAutoInc{}),
 			sortingCol:   "id",
 			expectedData: []string{"record 1", "record 2", "record 3"},
 		},
 		{
-			tableName:    "ulid_pk",
+			tableName:    testutils.TableName(is, db, &UlidPk{}),
 			sortingCol:   "id",
 			expectedData: []string{"ULID record 1", "ULID record 2"},
 		},
 		{
-			tableName:    "timestamp_ordered",
+			tableName:    testutils.TableName(is, db, &TimestampOrdered{}),
 			sortingCol:   "created_at",
 			expectedData: []string{"Timestamp record 1", "Timestamp record 2"},
 		},

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -381,6 +381,7 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 		ID  int    `gorm:"primaryKey;autoIncrement"`
 		Str string `gorm:"size:50"`
 	}
+	tablename := testutils.TableName(is, db, &Table{})
 
 	is.NoErr(db.Migrator().DropTable(&Table{}))
 
@@ -412,10 +413,10 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 	is.NoErr(err)
 
 	iterator, err := newSnapshotIterator(snapshotIteratorConfig{
-		tableSortColumns: map[string]string{"string_sorting": "str"},
+		tableSortColumns: map[string]string{tablename: "str"},
 		db:               db.Conn(),
 		database:         "meroxadb",
-		tables:           []string{"string_sorting"},
+		tables:           []string{tablename},
 		serverID:         serverID,
 	})
 	is.NoErr(err)

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -153,7 +153,7 @@ func TestSource_EmptyChunkRead(t *testing.T) {
 
 func TestUnsafeSnapshot(t *testing.T) {
 	is := is.New(t)
-	db := testutils.Gorm(is)
+	db := testutils.Connection(t)
 	var err error
 
 	type TableWithoutPK struct {

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -49,7 +49,7 @@ func TestSource_ConsistentSnapshot(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -94,7 +94,7 @@ func TestSource_NonZeroSnapshotStart(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -123,7 +123,7 @@ func TestSource_EmptyChunkRead(t *testing.T) {
 	ctx := testutils.TestContext(t)
 	is := is.New(t)
 
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 
 	testutils.RecreateUsersTable(is, db)
 
@@ -153,7 +153,7 @@ func TestSource_EmptyChunkRead(t *testing.T) {
 
 func TestUnsafeSnapshot(t *testing.T) {
 	is := is.New(t)
-	db := testutils.Connection(t)
+	db := testutils.NewDB(t)
 	var err error
 
 	type TableWithoutPK struct {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -44,14 +44,10 @@ var ServerID = "1"
 // don't manage sql connections, so we need to store them somehow.
 type DB struct {
 	*gorm.DB
-	conn *sqlx.DB
+	SqlxDB *sqlx.DB
 }
 
-func (c DB) Conn() *sqlx.DB {
-	return c.conn
-}
-
-func Connection(t *testing.T) DB {
+func NewDB(t *testing.T) DB {
 	is := is.New(t)
 
 	// Individual iterators assume that parseTime has already been configured to true, so
@@ -74,7 +70,7 @@ func Connection(t *testing.T) DB {
 		sqlxDB.Close()
 	})
 
-	return DB{DB: db, conn: sqlxDB}
+	return DB{DB: db, SqlxDB: sqlxDB}
 }
 
 func TableName(is *is.I, db DB, model any) string {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -132,7 +132,7 @@ func (u User) StructuredData() opencdc.StructuredData {
 }
 
 func RecreateUsersTable(is *is.I, db DB) {
-	db.Migrator().DropTable(&User{})
+	is.NoErr(db.Migrator().DropTable(&User{}))
 	is.NoErr(db.AutoMigrate(&User{}))
 }
 


### PR DESCRIPTION
### Description

PR #75 did add gorm to simplify CRUD logic as an experiment. I did really like it, and simplified quite a lot of stuff, so this pr finishes migration of all tests to gorm.

This also fixes annoying ci tests randomly failing, as every test data insert is now covered with a gorm transaction by default. We could also do that previously, but gorm makes it much more straightforward.

The main contra that I see is that we need to hold a gorm.DB and a sqlx.DB structs. Individual iterators don't create their own sql connections. Also this is adding yet another dependency, test only though.
I happily pay the tradeoffs though, the removed code was very annoying to write in the first place.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.