### PR TITLE
MySQL 5.5 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,8 @@ down:
 .PHONY: connect
 connect:
 	docker exec -it mysql_db mysql -u root -p'meroxaadmin' meroxadb
+
+.PHONY: fmt
+fmt:
+	gofumpt -l -w .
+	gci write --skip-generated  .

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/conduitio/conduit-commons v0.5.1
 	github.com/conduitio/conduit-connector-sdk v0.13.1
+	github.com/daixiang0/gci v0.13.5
 	github.com/go-mysql-org/go-mysql v1.11.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golangci/golangci-lint v1.64.2
@@ -19,6 +20,7 @@ require (
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/gorm v1.25.12
+	mvdan.cc/gofumpt v0.7.0
 )
 
 require (
@@ -99,7 +101,6 @@ require (
 	github.com/ckaznocha/intrange v0.3.0 // indirect
 	github.com/conduitio/conduit-connector-protocol v0.9.0 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
-	github.com/daixiang0/gci v0.13.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
@@ -251,6 +252,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.6.0 // indirect
-	mvdan.cc/gofumpt v0.7.0 // indirect
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 )

--- a/source.go
+++ b/source.go
@@ -142,7 +142,7 @@ func (s *Source) Teardown(ctx context.Context) error {
 func (s *Source) getAndFilterTables(ctx context.Context, db *sqlx.DB, database string) ([]string, error) {
 	query := "SELECT table_name FROM information_schema.tables WHERE table_schema = ?"
 
-	rows, err := db.Queryx(query, database)
+	rows, err := db.Queryx(query, database) //nolint:sqlclosecheck //false positive in latest version. Issue #35
 	if err != nil {
 		sdk.Logger(ctx).Error().Err(err).Msg("failed to query tables")
 		return nil, fmt.Errorf("failed to query tables: %w", err)

--- a/tools.go
+++ b/tools.go
@@ -18,5 +18,7 @@ package main
 
 import (
 	_ "github.com/conduitio/conduit-connector-sdk/conn-sdk-cli"
+	_ "github.com/daixiang0/gci"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "mvdan.cc/gofumpt"
 )


### PR DESCRIPTION
### Description

We're migrating legacy mysql 5.5 databases into postgres.
And the only reason not to use conduit-mysql-connector is `start transaction read only` statement on initialization: read-only transactions were implemented in mysql 5.7.

Read-only transactions are just an optimization which isn't required in most cases.

This MR disables read-only transactions if mysql-version is lower then 5.7

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.