### PR TITLE
Feature: add new noSnapshot source config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ pipelines:
           # Type: int
           # Required: no
           fetchSize: "10000"
+          # NoSnapshot prevents the connector from doing table snapshots and
+          # makes it start directly in cdc mode.
+          # Type: bool
+          # Required: no
+          noSnapshot: "false"
           # SortingColumn allows to force using a custom column to sort the
           # snapshot.
           # Type: string

--- a/README.md
+++ b/README.md
@@ -128,31 +128,31 @@ pipelines:
           # Type: string
           # Required: yes
           tables: ""
-          # DisableCanalLogs disables verbose logs.
+          # DisableLogs disables verbose cdc driver logs.
           # Type: bool
           # Required: no
-          disableCanalLogs: "false"
+          cdc.disableLogs: "false"
+          # EnabledSnapshot prevents the connector from doing table snapshots
+          # and makes it start directly in cdc mode.
+          # Type: bool
+          # Required: no
+          snapshot.enabled: "false"
           # FetchSize limits how many rows should be retrieved on each database
-          # fetch.
+          # fetch on snapshot mode.
           # Type: int
           # Required: no
-          fetchSize: "10000"
-          # NoSnapshot prevents the connector from doing table snapshots and
-          # makes it start directly in cdc mode.
-          # Type: bool
-          # Required: no
-          noSnapshot: "false"
-          # SortingColumn allows to force using a custom column to sort the
-          # snapshot.
-          # Type: string
-          # Required: no
-          tableConfig.*.sortingColumn: ""
+          snapshot.fetchSize: "10000"
           # UnsafeSnapshot allows a snapshot of a table with neither a primary
           # key nor a defined sorting column. The opencdc.Position won't record
           # the last record read from a table.
           # Type: bool
           # Required: no
-          unsafeSnapshot: "false"
+          snapshot.unsafe: "false"
+          # SortingColumn allows to force using a custom column to sort the
+          # snapshot.
+          # Type: string
+          # Required: no
+          tableConfig.*.sortingColumn: ""
           # Maximum delay before an incomplete batch is read from the source.
           # Type: duration
           # Required: no

--- a/connector.yaml
+++ b/connector.yaml
@@ -134,6 +134,13 @@ specification:
         type: int
         default: "10000"
         validations: []
+      - name: noSnapshot
+        description: |-
+          NoSnapshot prevents the connector from doing table snapshots and makes it
+          start directly in cdc mode.
+        type: bool
+        default: ""
+        validations: []
       - name: tableConfig.*.sortingColumn
         description: SortingColumn allows to force using a custom column to sort the snapshot.
         type: string

--- a/connector.yaml
+++ b/connector.yaml
@@ -124,34 +124,34 @@ specification:
         validations:
           - type: required
             value: ""
-      - name: disableCanalLogs
-        description: DisableCanalLogs disables verbose logs.
+      - name: cdc.disableLogs
+        description: DisableLogs disables verbose cdc driver logs.
         type: bool
         default: ""
         validations: []
-      - name: fetchSize
-        description: FetchSize limits how many rows should be retrieved on each database fetch.
+      - name: snapshot.enabled
+        description: |-
+          EnabledSnapshot prevents the connector from doing table snapshots and makes it
+          start directly in cdc mode.
+        type: bool
+        default: ""
+        validations: []
+      - name: snapshot.fetchSize
+        description: FetchSize limits how many rows should be retrieved on each database fetch on snapshot mode.
         type: int
         default: "10000"
         validations: []
-      - name: noSnapshot
+      - name: snapshot.unsafe
         description: |-
-          NoSnapshot prevents the connector from doing table snapshots and makes it
-          start directly in cdc mode.
+          UnsafeSnapshot allows a snapshot of a table with neither a primary key
+          nor a defined sorting column. The opencdc.Position won't record the last record
+          read from a table.
         type: bool
         default: ""
         validations: []
       - name: tableConfig.*.sortingColumn
         description: SortingColumn allows to force using a custom column to sort the snapshot.
         type: string
-        default: ""
-        validations: []
-      - name: unsafeSnapshot
-        description: |-
-          UnsafeSnapshot allows a snapshot of a table with neither a primary key
-          nor a defined sorting column. The opencdc.Position won't record the last record
-          read from a table.
-        type: bool
         default: ""
         validations: []
       - name: sdk.batch.delay

--- a/source.go
+++ b/source.go
@@ -60,6 +60,10 @@ type SourceConfig struct {
 	// read from a table.
 	UnsafeSnapshot bool `json:"unsafeSnapshot"`
 
+	// NoSnapshot prevents the connector from doing table snapshots and makes it
+	// start directly in cdc mode.
+	NoSnapshot bool `json:"noSnapshot"`
+
 	mysqlCfg *mysql.Config
 }
 

--- a/source.go
+++ b/source.go
@@ -49,20 +49,20 @@ type SourceConfig struct {
 	//  - e.g. "-.*meta$, wp_postmeta" will exclude all tables ending with "meta" but include the table "wp_postmeta".
 	Tables []string `json:"tables" validate:"required"`
 
-	// DisableCanalLogs disables verbose logs.
-	DisableCanalLogs bool `json:"disableCanalLogs"`
+	// DisableLogs disables verbose cdc driver logs.
+	DisableLogs bool `json:"cdc.disableLogs"`
 
-	// FetchSize limits how many rows should be retrieved on each database fetch.
-	FetchSize uint64 `json:"fetchSize" default:"10000"`
+	// FetchSize limits how many rows should be retrieved on each database fetch on snapshot mode.
+	FetchSize uint64 `json:"snapshot.fetchSize" default:"10000"`
 
 	// UnsafeSnapshot allows a snapshot of a table with neither a primary key
 	// nor a defined sorting column. The opencdc.Position won't record the last record
 	// read from a table.
-	UnsafeSnapshot bool `json:"unsafeSnapshot"`
+	UnsafeSnapshot bool `json:"snapshot.unsafe"`
 
-	// NoSnapshot prevents the connector from doing table snapshots and makes it
+	// EnabledSnapshot prevents the connector from doing table snapshots and makes it
 	// start directly in cdc mode.
-	NoSnapshot bool `json:"noSnapshot"`
+	EnabledSnapshot bool `json:"snapshot.enabled"`
 
 	mysqlCfg *mysql.Config
 }
@@ -161,9 +161,9 @@ func (s *Source) Open(ctx context.Context, sdkPos opencdc.Position) (err error) 
 		tables:                s.config.Tables,
 		serverID:              serverID,
 		mysqlConfig:           s.config.MysqlCfg(),
-		disableCanalLogging:   s.config.DisableCanalLogs,
+		disableCanalLogging:   s.config.DisableLogs,
 		fetchSize:             s.config.FetchSize,
-		noSnapshot:            s.config.NoSnapshot,
+		noSnapshot:            s.config.EnabledSnapshot,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot iterator: %w", err)

--- a/source.go
+++ b/source.go
@@ -163,6 +163,7 @@ func (s *Source) Open(ctx context.Context, sdkPos opencdc.Position) (err error) 
 		mysqlConfig:           s.config.MysqlCfg(),
 		disableCanalLogging:   s.config.DisableCanalLogs,
 		fetchSize:             s.config.FetchSize,
+		noSnapshot:            s.config.NoSnapshot,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot iterator: %w", err)

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -33,7 +33,7 @@ func testSource(ctx context.Context, is *is.I, cfg map[string]string) (sdk.Sourc
 	source := &Source{}
 
 	cfg["dsn"] = testutils.DSN
-	cfg["disableCanalLogs"] = "true"
+	cfg["cdc.disableLogs"] = "true"
 
 	err := sdk.Util.ParseConfig(ctx,
 		cfg, source.Config(),
@@ -114,8 +114,8 @@ func TestSource_NonZeroSnapshotStart(t *testing.T) {
 	}
 
 	source, teardown := testSource(ctx, is, map[string]string{
-		"tables":    "users",
-		"fetchSize": "10",
+		"tables":             "users",
+		"snapshot.fetchSize": "10",
 	})
 	defer teardown()
 
@@ -146,8 +146,8 @@ func TestSource_EmptyChunkRead(t *testing.T) {
 	}
 
 	source, teardown := testSource(ctx, is, map[string]string{
-		"tables":    "users",
-		"fetchSize": "10",
+		"tables":             "users",
+		"snapshot.fetchSize": "10",
 	})
 	defer teardown()
 
@@ -178,8 +178,8 @@ func TestSource_UnsafeSnapshot(t *testing.T) {
 
 	ctx := testutils.TestContext(t)
 	source, teardown := testSource(ctx, is, map[string]string{
-		"tables":         "table_without_pk",
-		"unsafeSnapshot": "true",
+		"tables":          "table_without_pk",
+		"snapshot.unsafe": "true",
 	})
 	defer teardown()
 
@@ -362,8 +362,8 @@ func TestNoSnapshot(t *testing.T) {
 	user2 := testutils.InsertUser(is, db, 2)
 
 	source, teardown := testSource(ctx, is, map[string]string{
-		"tables":     "users",
-		"noSnapshot": "true",
+		"tables":           "users",
+		"snapshot.enabled": "true",
 	})
 	defer teardown()
 

--- a/source_integration_test.go
+++ b/source_integration_test.go
@@ -347,3 +347,7 @@ func TestSource_CompositeKey(t *testing.T) {
 		is.Equal(len(parsedKeySchema.Fields), 2) // Both parts of the composite key
 	}
 }
+
+func TestNoSnapshot(t *testing.T) {
+
+}


### PR DESCRIPTION
### Description

Adds a new source config parameter, `noSnapshot`, that prevents the source iterator from doing a snapshot.
Fixes #31

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.