### PR TITLE
Mariadb compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ build:
 test: up-database
 	go test $(GOTEST_FLAGS) -v -race ./...
 
+.PHONY: test-mysql
+test-mysql:
+	DB_IMAGE=mysql:8.0.39 make down test
+
+.PHONY: test-mariadb
+test-mariadb:
+	DB_IMAGE=mariadb:10.11 make down test
+
 .PHONY: generate
 generate:
 	go generate ./...

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,19 @@ build:
 	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-mysql.version=${VERSION}'" -o conduit-connector-mysql cmd/connector/main.go
 
 .PHONY: test
-test: up-database
+test: test-mysql test-mariadb down
+
+.PHONY: test-internal
+test-internal: up-database
 	go test $(GOTEST_FLAGS) -v -race ./...
 
 .PHONY: test-mysql
 test-mysql:
-	DB_IMAGE=mysql:8.0.39 make down test
+	export DB_IMAGE=mysql:8.0.39 && make test-internal
 
 .PHONY: test-mariadb
 test-mariadb:
-	DB_IMAGE=mariadb:10.11 make down test
+	export DB_IMAGE=mariadb:11.4 && make test-internal
 
 .PHONY: generate
 generate:

--- a/cdc_iterator.go
+++ b/cdc_iterator.go
@@ -58,10 +58,14 @@ func newCdcIterator(ctx context.Context, config cdcIteratorConfig) (*cdcIterator
 	err := config.db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version)
 	if err != nil {
 		sdk.Logger(ctx).Warn().Err(err).Msg("failed to detect database version, defaulting to MySQL")
-	} else if strings.Contains(version, "MariaDB") {
-		flavor = "mariadb"
-	} else {
 		flavor = "mysql"
+	} else {
+		switch {
+		case strings.Contains(version, "MariaDB"):
+			flavor = "mariadb"
+		default:
+			flavor = "mysql"
+		}
 	}
 
 	canal, err := common.NewCanal(ctx, common.CanalConfig{

--- a/common/utils.go
+++ b/common/utils.go
@@ -32,6 +32,7 @@ type CanalConfig struct {
 	*mysql.Config
 	Tables         []string
 	DisableLogging bool
+	Flavor         string // "mysql" or "mariadb"
 }
 
 func NewCanal(ctx context.Context, config CanalConfig) (*canal.Canal, error) {
@@ -39,6 +40,7 @@ func NewCanal(ctx context.Context, config CanalConfig) (*canal.Canal, error) {
 	cfg.Addr = config.Addr
 	cfg.User = config.User
 	cfg.Password = config.Passwd
+	cfg.Flavor = config.Flavor
 
 	cfg.IncludeTableRegex = config.Tables
 	if config.DisableLogging {

--- a/schema_test.go
+++ b/schema_test.go
@@ -332,7 +332,7 @@ func TestSchema_Payload_SQLX_Rows(t *testing.T) {
 	expectedSchema := expectedPayloadRecordSchema(is, tableName)
 
 	is.Equal("", cmp.Diff(expectedSchema, actualSchema)) // expected schema != actual schema
-	is.Equal("", cmp.Diff(testData, formatted))          // expected data != actual data
+	testutils.CompareData(is, formatted, testData)       // Use function from test_utils
 }
 
 func TestSchema_Payload_canal_RowsEvent(t *testing.T) {
@@ -373,7 +373,7 @@ func TestSchema_Payload_canal_RowsEvent(t *testing.T) {
 	expectedSchema := expectedPayloadRecordSchema(is, tableName)
 
 	is.Equal("", cmp.Diff(expectedSchema, actualSchema)) // expected schema != actual schema
-	is.Equal("", cmp.Diff(testData, formatted))          // expected data != actual data
+	testutils.CompareData(is, formatted, testData)       // expected data != actual data
 }
 
 func TestSchema_Key(t *testing.T) {

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -393,17 +393,33 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 		{Str: "Apple"},
 	}
 
-	sorted := []Table{
-		{Str: "_apple"},
-		{Str: "123apple"},
-		{Str: "apple"},
-		{Str: "āpple"},
-		{Str: "Apple"},
-		{Str: "BANANA"},
-		{Str: "Zebra"},
-	}
-
 	is.NoErr(db.Create(&data).Error)
+
+	// Different databases may sort strings differently (MySQL vs MariaDB)
+	var expectedSortedStrings []string
+	if testutils.DetectedDBType == testutils.DatabaseTypeMariaDB {
+		// MariaDB sorting order
+		expectedSortedStrings = []string{
+			"123apple",
+			"apple",
+			"āpple",
+			"Apple",
+			"BANANA",
+			"Zebra",
+			"_apple",
+		}
+	} else {
+		// MySQL sorting order
+		expectedSortedStrings = []string{
+			"_apple",
+			"123apple",
+			"apple",
+			"āpple",
+			"Apple",
+			"BANANA",
+			"Zebra",
+		}
+	}
 
 	serverID, err := common.GetServerID(ctx, db.SqlxDB)
 	is.NoErr(err)
@@ -434,12 +450,11 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 		recs = append(recs, rec)
 	}
 
-	is.Equal(len(recs), len(sorted))
+	is.Equal(len(recs), len(expectedSortedStrings))
 
-	for i, expectedData := range sorted {
-		actual := recs[i]
-		is.Equal(actual.Operation, opencdc.OperationSnapshot)
-		is.Equal(actual.Payload.After.(opencdc.StructuredData)["str"].(string), expectedData.Str)
+	for i, rec := range recs {
+		is.Equal(rec.Operation, opencdc.OperationSnapshot)
+		is.Equal(rec.Payload.After.(opencdc.StructuredData)["str"].(string), expectedSortedStrings[i])
 	}
 
 	is.NoErr(iterator.Teardown(ctx))

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 services:
   db:
     container_name: mysql_db
-    image: mysql:8.0.39
+    image: ${DB_IMAGE:-mysql:8.0.39}
     environment:
       MYSQL_DATABASE: meroxadb
       MYSQL_USER: meroxauser
@@ -15,6 +15,14 @@ services:
       - '3306:3306'
     networks:
       - main
+    command: >
+      --binlog-format=ROW
+      --log-bin=mysql-bin
+      --server-id=1
+    # We've removed the volume here to avoid persisting data between test runs
+    # This ensures each test starts with a clean database state
+    tmpfs:
+      - /var/lib/mysql:rw,noexec,nosuid,size=1024m
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
       interval: 1s

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -19,12 +19,15 @@ services:
       --binlog-format=ROW
       --log-bin=mysql-bin
       --server-id=1
-    # We've removed the volume here to avoid persisting data between test runs
-    # This ensures each test starts with a clean database state
     tmpfs:
       - /var/lib/mysql:rw,noexec,nosuid,size=1024m
     healthcheck:
-      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
+      test: >
+        /bin/bash -c 'if echo "$DB_IMAGE" | grep -q "mariadb"; then
+          mariadb-admin ping -h localhost;
+        else
+          mysqladmin ping -h localhost;
+        fi'
       interval: 1s
       timeout: 20s
       retries: 30

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -39,20 +39,27 @@ import (
 	gormschema "gorm.io/gorm/schema"
 )
 
-// Constants
+// Constants.
 const DSN = "root:meroxaadmin@tcp(127.0.0.1:3306)/meroxadb"
 
-// Database types supported by this connector
+// Database types supported by this connector.
 const (
 	DatabaseTypeMySQL   = "mysql"
 	DatabaseTypeMariaDB = "mariadb"
+
+	// Avro type constants.
+	AvroTypeLong = "long"
+	AvroTypeInt  = "int"
 )
 
-// Global Variables
+// Global Variables.
 var ServerID = "1"
 
-// DetectedDBType stores the database type (MySQL or MariaDB) detected at initialization
+// DetectedDBType stores the database type (MySQL or MariaDB) detected at initialization.
 var DetectedDBType string
+
+// schemaInitOnce ensures schema initialization happens only once.
+var schemaInitOnce sync.Once
 
 // Type Definitions
 
@@ -63,22 +70,51 @@ type DB struct {
 	SqlxDB *sqlx.DB
 }
 
-// Initialize schemas based on database type detection and cache database type
-func init() {
-	// Try to connect and detect database type
-	tempDB, err := sqlx.Connect("mysql", DSN+"?parseTime=true")
-	if err == nil {
-		payload, key, err := createSchemas(tempDB)
-		if err == nil {
-			// Update the schema definitions with the results from createSchemas
-			userPayloadSchema = payload
-			userKeySchema = key
-		}
-		tempDB.Close()
+// Initialize schemas at runtime (instead of init).
+var (
+	userPayloadSchema = AvroSchema{
+		Name: "mysql.users_payload",
+		Type: "record",
+		Fields: []AvroSchemaField{
+			{Name: "id", Type: AvroTypeLong},
+			{Name: "username", Type: "string"},
+			{Name: "email", Type: "string"},
+			{Name: "created_at", Type: "string"},
+		},
 	}
+	userKeySchema = AvroSchema{
+		Name:   "mysql.users_key",
+		Type:   "record",
+		Fields: []AvroSchemaField{{Name: "id", Type: AvroTypeLong}},
+	}
+)
+
+// EnsureSchemas sets up schemas based on database type detection and caches database type.
+// It's designed to run only once even if called multiple times.
+func EnsureSchemas(t *testing.T) {
+	is := is.New(t)
+
+	// Use sync.Once to ensure this runs only one time, no matter how many goroutines call it
+	schemaInitOnce.Do(func() {
+		// Try to connect and detect database type
+		tempDB, err := sqlx.Connect("mysql", DSN+"?parseTime=true")
+		if err != nil {
+			is.NoErr(fmt.Errorf("failed to connect to database for schema initialization: %w", err))
+		}
+		defer tempDB.Close()
+
+		payload, key, err := createSchemas(tempDB)
+		if err != nil {
+			is.NoErr(fmt.Errorf("failed to create schemas: %w", err))
+		}
+
+		// Update the schema definitions with the results from createSchemas
+		userPayloadSchema = payload
+		userKeySchema = key
+	})
 }
 
-// Database type detection functions
+// Database type detection functions.
 func detectDatabaseType(db *sqlx.DB) (string, error) {
 	// If we already detected the type, return the cached value
 	if DetectedDBType != "" {
@@ -88,7 +124,7 @@ func detectDatabaseType(db *sqlx.DB) (string, error) {
 	var version string
 	err := db.Get(&version, "SELECT VERSION()")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get database version: %w", err)
 	}
 
 	if strings.Contains(version, "MariaDB") {
@@ -100,20 +136,20 @@ func detectDatabaseType(db *sqlx.DB) (string, error) {
 	return DatabaseTypeMySQL, nil
 }
 
-// getAvroIntegerType returns the appropriate Avro type based on database type
+// getAvroIntegerType returns the appropriate Avro type based on database type.
 func getAvroIntegerType(db *sqlx.DB) (string, error) {
 	dbType, err := detectDatabaseType(db)
 	if err != nil {
-		return "long", err
+		return AvroTypeLong, fmt.Errorf("failed to detect database type: %w", err)
 	}
 
 	if dbType == DatabaseTypeMariaDB {
-		return "int", nil
+		return AvroTypeInt, nil
 	}
-	return "long", nil
+	return AvroTypeLong, nil
 }
 
-// createSchemas generates the schema for the current database
+// createSchemas generates the schema for the current database.
 func createSchemas(db *sqlx.DB) (AvroSchema, AvroSchema, error) {
 	idType, err := getAvroIntegerType(db)
 	if err != nil {
@@ -140,9 +176,13 @@ func createSchemas(db *sqlx.DB) (AvroSchema, AvroSchema, error) {
 	return payloadSchema, keySchema, nil
 }
 
-// Database connection functions
+// Database connection functions.
 func NewDB(t *testing.T) DB {
 	is := is.New(t)
+
+	// Ensure schemas are initialized when creating a new DB
+	// This will only do the actual work once
+	EnsureSchemas(t)
 
 	// Individual iterators assume that parseTime has already been configured to true, so
 	// they have no knowledge whether that has actually been the case.
@@ -208,24 +248,6 @@ type User struct {
 	Email     string    `db:"email"`
 	CreatedAt time.Time `db:"created_at"`
 }
-
-var (
-	userPayloadSchema = AvroSchema{
-		Name: "mysql.users_payload",
-		Type: "record",
-		Fields: []AvroSchemaField{
-			{Name: "id", Type: "long"},
-			{Name: "username", Type: "string"},
-			{Name: "email", Type: "string"},
-			{Name: "created_at", Type: "string"},
-		},
-	}
-	userKeySchema = AvroSchema{
-		Name:   "mysql.users_key",
-		Type:   "record",
-		Fields: []AvroSchemaField{{Name: "id", Type: "long"}},
-	}
-)
 
 type AvroSchema struct {
 	Name   string            `json:"name"`
@@ -452,7 +474,7 @@ func assertSchema(ctx context.Context, is *is.I, metadata opencdc.Metadata) {
 	}
 }
 
-// normalizeSchemaTypes normalizes int/long types for comparison
+// normalizeSchemaTypes normalizes int/long types for comparison.
 func normalizeSchemaTypes(schema *AvroSchema) {
 	for i := range schema.Fields {
 		if schema.Fields[i].Type == "int" || schema.Fields[i].Type == "long" {
@@ -479,10 +501,14 @@ func normalizeData(data interface{}) interface{} {
 		return int64(v)
 	case uint64:
 		// Convert uint64 to int64 for MariaDB compatibility
-		return int64(v)
+		// Using conditional for overflow check
+		if v <= 9223372036854775807 { // Max value for int64
+			return int64(v)
+		}
+		return v // Keep as uint64 if it would overflow
 	case uint32:
 		// Convert uint32 to int64 for MariaDB compatibility
-		return int64(v)
+		return int64(v) // uint32 max value fits in int64, no overflow possible
 	default:
 		return v
 	}
@@ -497,7 +523,12 @@ func normalizeMapData(data map[string]any) map[string]any {
 		case uint32:
 			result[k] = int64(val)
 		case uint64:
-			result[k] = int64(val)
+			// Using conditional for overflow check
+			if val <= 9223372036854775807 { // Max value for int64
+				result[k] = int64(val)
+			} else {
+				result[k] = val // Keep as uint64 if it would overflow
+			}
 		default:
 			result[k] = val
 		}
@@ -511,7 +542,7 @@ func CompareData(is *is.I, actual, expected map[string]any) {
 	is.Equal("", cmp.Diff(normalizedExpected, normalizedActual))
 }
 
-// Canal helper functions
+// Canal helper functions.
 func newCanal(ctx context.Context, is *is.I, tablename string) *canal.Canal {
 	is.Helper()
 
@@ -583,6 +614,6 @@ func (h *testEventHandler) OnRow(e *canal.RowsEvent) error {
 }
 
 // Note: this doesnt seem to be used anywhere
-/* func (h *testEventHandler) String() string {
-	return "testEventHandler"
-} */
+// func (h *testEventHandler) String() string {
+// 	return "testEventHandler"
+// }

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -38,9 +39,22 @@ import (
 	gormschema "gorm.io/gorm/schema"
 )
 
+// Constants
 const DSN = "root:meroxaadmin@tcp(127.0.0.1:3306)/meroxadb"
 
+// Database types supported by this connector
+const (
+	DatabaseTypeMySQL   = "mysql"
+	DatabaseTypeMariaDB = "mariadb"
+)
+
+// Global Variables
 var ServerID = "1"
+
+// DetectedDBType stores the database type (MySQL or MariaDB) detected at initialization
+var DetectedDBType string
+
+// Type Definitions
 
 // DB is a gorm wrapper that also holds a sqlx DB. Iterators
 // don't manage sql connections, so we need to store them somehow.
@@ -49,6 +63,84 @@ type DB struct {
 	SqlxDB *sqlx.DB
 }
 
+// Initialize schemas based on database type detection and cache database type
+func init() {
+	// Try to connect and detect database type
+	tempDB, err := sqlx.Connect("mysql", DSN+"?parseTime=true")
+	if err == nil {
+		payload, key, err := createSchemas(tempDB)
+		if err == nil {
+			// Update the schema definitions with the results from createSchemas
+			userPayloadSchema = payload
+			userKeySchema = key
+		}
+		tempDB.Close()
+	}
+}
+
+// Database type detection functions
+func detectDatabaseType(db *sqlx.DB) (string, error) {
+	// If we already detected the type, return the cached value
+	if DetectedDBType != "" {
+		return DetectedDBType, nil
+	}
+
+	var version string
+	err := db.Get(&version, "SELECT VERSION()")
+	if err != nil {
+		return "", err
+	}
+
+	if strings.Contains(version, "MariaDB") {
+		DetectedDBType = DatabaseTypeMariaDB
+		return DatabaseTypeMariaDB, nil
+	}
+
+	DetectedDBType = DatabaseTypeMySQL
+	return DatabaseTypeMySQL, nil
+}
+
+// getAvroIntegerType returns the appropriate Avro type based on database type
+func getAvroIntegerType(db *sqlx.DB) (string, error) {
+	dbType, err := detectDatabaseType(db)
+	if err != nil {
+		return "long", err
+	}
+
+	if dbType == DatabaseTypeMariaDB {
+		return "int", nil
+	}
+	return "long", nil
+}
+
+// createSchemas generates the schema for the current database
+func createSchemas(db *sqlx.DB) (AvroSchema, AvroSchema, error) {
+	idType, err := getAvroIntegerType(db)
+	if err != nil {
+		return AvroSchema{}, AvroSchema{}, err
+	}
+
+	payloadSchema := AvroSchema{
+		Name: "mysql.users_payload",
+		Type: "record",
+		Fields: []AvroSchemaField{
+			{Name: "id", Type: idType},
+			{Name: "username", Type: "string"},
+			{Name: "email", Type: "string"},
+			{Name: "created_at", Type: "string"},
+		},
+	}
+
+	keySchema := AvroSchema{
+		Name:   "mysql.users_key",
+		Type:   "record",
+		Fields: []AvroSchemaField{{Name: "id", Type: idType}},
+	}
+
+	return payloadSchema, keySchema, nil
+}
+
+// Database connection functions
 func NewDB(t *testing.T) DB {
 	is := is.New(t)
 
@@ -67,6 +159,9 @@ func NewDB(t *testing.T) DB {
 	sqlDB, err := db.DB()
 	is.NoErr(err)
 	sqlxDB := sqlx.NewDb(sqlDB, "mysql")
+
+	// Fixes sporadic connection issues, as per https://github.com/go-sql-driver/mysql/issues/674
+	sqlxDB.SetConnMaxLifetime(time.Second)
 
 	t.Cleanup(func() {
 		sqlxDB.Close()
@@ -281,7 +376,9 @@ func ReadAndAssertDelete(
 }
 
 func isDataEqual(is *is.I, actual, expected any) {
-	is.Equal("", cmp.Diff(actual, expected)) // actual (-) != expected (+)
+	normalizedActual := normalizeData(actual)
+	normalizedExpected := normalizeData(expected)
+	is.Equal("", cmp.Diff(normalizedActual, normalizedExpected)) // actual (-) != expected (+)
 }
 
 func ReadAndAssertSnapshot(
@@ -330,7 +427,10 @@ func assertSchema(ctx context.Context, is *is.I, metadata opencdc.Metadata) {
 		var actualSchema AvroSchema
 		is.NoErr(json.Unmarshal(s.Bytes, &actualSchema))
 
-		isDataEqual(is, actualSchema, userPayloadSchema)
+		// Normalize schema before comparing
+		normalizeSchemaTypes(&actualSchema)
+		normalizeSchemaTypes(&userPayloadSchema)
+		is.Equal("", cmp.Diff(actualSchema, userPayloadSchema))
 	}
 
 	{ // key schema
@@ -345,10 +445,73 @@ func assertSchema(ctx context.Context, is *is.I, metadata opencdc.Metadata) {
 		var actualSchema AvroSchema
 		is.NoErr(json.Unmarshal(s.Bytes, &actualSchema))
 
-		isDataEqual(is, actualSchema, userKeySchema)
+		// Normalize schema before comparing
+		normalizeSchemaTypes(&actualSchema)
+		normalizeSchemaTypes(&userKeySchema)
+		is.Equal("", cmp.Diff(actualSchema, userKeySchema))
 	}
 }
 
+// normalizeSchemaTypes normalizes int/long types for comparison
+func normalizeSchemaTypes(schema *AvroSchema) {
+	for i := range schema.Fields {
+		if schema.Fields[i].Type == "int" || schema.Fields[i].Type == "long" {
+			schema.Fields[i].Type = "integer" // neutral name for comparison
+		}
+	}
+}
+
+func normalizeData(data interface{}) interface{} {
+	switch v := data.(type) {
+	case opencdc.StructuredData:
+		result := opencdc.StructuredData{}
+		for k, val := range v {
+			result[k] = normalizeData(val)
+		}
+		return result
+	case map[string]interface{}:
+		result := map[string]interface{}{}
+		for k, val := range v {
+			result[k] = normalizeData(val)
+		}
+		return result
+	case int32:
+		return int64(v)
+	case uint64:
+		// Convert uint64 to int64 for MariaDB compatibility
+		return int64(v)
+	case uint32:
+		// Convert uint32 to int64 for MariaDB compatibility
+		return int64(v)
+	default:
+		return v
+	}
+}
+
+func normalizeMapData(data map[string]any) map[string]any {
+	result := make(map[string]any, len(data))
+	for k, v := range data {
+		switch val := v.(type) {
+		case int32:
+			result[k] = int64(val)
+		case uint32:
+			result[k] = int64(val)
+		case uint64:
+			result[k] = int64(val)
+		default:
+			result[k] = val
+		}
+	}
+	return result
+}
+
+func CompareData(is *is.I, actual, expected map[string]any) {
+	normalizedActual := normalizeMapData(actual)
+	normalizedExpected := normalizeMapData(expected)
+	is.Equal("", cmp.Diff(normalizedExpected, normalizedActual))
+}
+
+// Canal helper functions
 func newCanal(ctx context.Context, is *is.I, tablename string) *canal.Canal {
 	is.Helper()
 
@@ -419,6 +582,7 @@ func (h *testEventHandler) OnRow(e *canal.RowsEvent) error {
 	}
 }
 
-func (h *testEventHandler) String() string {
+// Note: this doesnt seem to be used anywhere
+/* func (h *testEventHandler) String() string {
 	return "testEventHandler"
-}
+} */


### PR DESCRIPTION
### Description

(Continuing work from previous PR, #109)

Checks the db server version and sets the flavor for the NewCanal depending on if it is mariadb or mysql, so that it can use mariadb's native binlog events

Fixes # 108

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.