### PR TITLE
Mariadb compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-mysql:
     runs-on: ubuntu-latest
     services:
       mysql:
@@ -33,4 +33,42 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
+        run: go test -v -race -count=1 ./...
+
+  test-mariadb:
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_DATABASE: meroxadb
+          MARIADB_USER: meroxauser
+          MARIADB_PASSWORD: meroxapass
+          MARIADB_ROOT_PASSWORD: meroxaadmin
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=1s
+          --health-timeout=20s
+          --health-retries=30
+          --health-start-period=10s
+          --binlog-format=ROW
+          --log-bin=mysql-bin
+          --server-id=1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Test MariaDB
+        env:
+          MYSQL_TEST_USER: meroxauser
+          MYSQL_TEST_PASSWORD: meroxapass
+          MYSQL_TEST_DB: meroxadb
+          MYSQL_TEST_HOST: 127.0.0.1
+          MYSQL_TEST_PORT: 3306
         run: go test -v -race -count=1 ./...

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-mysql.version=${VERSION}'" -o conduit-connector-mysql cmd/connector/main.go
 
 .PHONY: test
-test: up-database
+test: up
 	go test $(GOTEST_FLAGS) -v -race ./...
 
 .PHONY: generate
@@ -23,17 +23,13 @@ install-tools:
 lint:
 	golangci-lint run
 
-.PHONY: up-database
-up-database:
-	docker compose -f test/docker-compose.yml up --quiet-pull -d db --wait
-
-.PHONY: up-adminer
-up-adminer:
-	docker compose -f test/docker-compose.yml up --quiet-pull -d adminer --wait
-
 .PHONY: up
 up:
-	docker compose -f test/docker-compose.yml up --wait
+	docker compose -f test/docker-compose.yml up mysql --wait
+
+.PHONY: up-mariadb
+up-mariadb:
+	docker compose -f test/docker-compose.yml up mariadb --wait
 
 .PHONY: down
 down:
@@ -42,6 +38,10 @@ down:
 .PHONY: connect
 connect:
 	docker exec -it mysql_db mysql -u root -p'meroxaadmin' meroxadb
+
+.PHONY: connect-mariadb
+connect-mariadb:
+	docker exec -it mariadb_db mariadb -u root -p'meroxaadmin' meroxadb
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Conduit Connector for MySQL
 
 <!-- readmegen:description -->
+
 ## Source
 
 A source connector pulls data from an external resource and pushes it to
@@ -69,43 +70,43 @@ The source connector uses [avro](https://avro.apache.org/docs/1.11.1/specificati
 
 Records produced by the MySQL source connector contain the following [opencdc record structure](https://conduit.io/docs/using/opencdc-record):
 
-*   **Operation**: Indicates the type of change (`create`, `update`, `delete`, `snapshot`).
-*   **Payload**:
-    *   `Before`: (Only present on CDC `update` operations) `opencdc.StructuredData` representing the row state before the change.
-    *   `After`: `opencdc.StructuredData` representing the row state after the change (or the current state for `snapshot` and `create`).
-*   **Key**: Identifies the specific row. See Snapshot/CDC sections below for details.
-*   **Position**: Represents the point in the data stream. It's a JSON object containing *either* a `snapshot_position` field *or* a `cdc_position` field, structured as described below.
-*   **Metadata**: Contains standard OpenCDC fields plus:
-    *   `mysql.server.id`: (CDC only) The originating MySQL server ID from the replication event header.
-    *   [Key](https://conduit.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduit.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
+- **Operation**: Indicates the type of change (`create`, `update`, `delete`, `snapshot`).
+- **Payload**:
+  - `Before`: (Only present on CDC `update` operations) `opencdc.StructuredData` representing the row state before the change.
+  - `After`: `opencdc.StructuredData` representing the row state after the change (or the current state for `snapshot` and `create`).
+- **Key**: Identifies the specific row. See Snapshot/CDC sections below for details.
+- **Position**: Represents the point in the data stream. It's a JSON object containing _either_ a `snapshot_position` field _or_ a `cdc_position` field, structured as described below.
+- **Metadata**: Contains standard OpenCDC fields plus:
+  - `mysql.server.id`: (CDC only) The originating MySQL server ID from the replication event header.
+  - [Key](https://conduit.io/docs/using/opencdc-record/#opencdckeyschema) and [payload](https://conduit.io/docs/using/opencdc-record/#opencdcpayloadschema) schema registry data.
 
 #### Snapshot Records
 
-*   **Operation**: `snapshot`.
-*   **Payload `After`**: `opencdc.StructuredData` with all column values.
-*   **Key**:
-    *   With Primary Key(s): `opencdc.StructuredData` using primary key columns and values.
-    *   Without Primary Key(s) (using `LIMIT`/`OFFSET`): `opencdc.RawData` string `"<table_name>_<row_offset>"`.
-*   **Position (`snapshot_position` field)**: A JSON object containing:
-    *   `snapshots`: (object) Maps table names to their specific snapshot position object.
-        *   *(Single Primary Key Table)*: Contains `last_read` (any) and `snapshot_end` (any).
-        *   *(Multiple Primary Key Table)*: Contains an array of objects, each with `key_name` (string), `last_read` (any), and `snapshot_end` (any).
-        *   *(No Primary Key Table)*: Table entry might be missing or empty (offset is not persisted).
+- **Operation**: `snapshot`.
+- **Payload `After`**: `opencdc.StructuredData` with all column values.
+- **Key**:
+  - With Primary Key(s): `opencdc.StructuredData` using primary key columns and values.
+  - Without Primary Key(s) (using `LIMIT`/`OFFSET`): `opencdc.RawData` string `"<table_name>_<row_offset>"`.
+- **Position (`snapshot_position` field)**: A JSON object containing:
+  - `snapshots`: (object) Maps table names to their specific snapshot position object.
+    - _(Single Primary Key Table)_: Contains `last_read` (any) and `snapshot_end` (any).
+    - _(Multiple Primary Key Table)_: Contains an array of objects, each with `key_name` (string), `last_read` (any), and `snapshot_end` (any).
+    - _(No Primary Key Table)_: Table entry might be missing or empty (offset is not persisted).
 
 #### CDC Records
 
-*   **Operation**: Either `create`, `update` or `delete`.
-*   **Key**:
-    *   With Primary Key(s): `opencdc.StructuredData` using primary key columns and values (from the `After` state).
-    *   Without Primary Key(s): `opencdc.RawData` string `"<binlog_file_name>_<log_position>"`.
-*   **Payload**:
-    *   `Before`: (For `update` only) `opencdc.StructuredData` with pre-update column values.
-    *   `After`: `opencdc.StructuredData` with post-change column values (for `create`, `update`) or pre-deletion values (for `delete`).
-*   **Position (`cdc_position` field)**: Encodes the binlog location in a JSON object with the following fields.
-    *   `name`: (string) Binlog file name.
-    *   `pos`: (uint32) Position within the binlog file.
-    *   `prev`: (object, optional) Position of the preceding event, containing `name` (string) and `pos` (uint32). Omitted if not applicable.
-    *   `idx`: (int, optional) Row index within a potentially multi-row MySQL replication event. Omitted if zero or not applicable.
+- **Operation**: Either `create`, `update` or `delete`.
+- **Key**:
+  - With Primary Key(s): `opencdc.StructuredData` using primary key columns and values (from the `After` state).
+  - Without Primary Key(s): `opencdc.RawData` string `"<binlog_file_name>_<log_position>"`.
+- **Payload**:
+  - `Before`: (For `update` only) `opencdc.StructuredData` with pre-update column values.
+  - `After`: `opencdc.StructuredData` with post-change column values (for `create`, `update`) or pre-deletion values (for `delete`).
+- **Position (`cdc_position` field)**: Encodes the binlog location in a JSON object with the following fields.
+  - `name`: (string) Binlog file name.
+  - `pos`: (uint32) Position within the binlog file.
+  - `prev`: (object, optional) Position of the preceding event, containing `name` (string) and `pos` (uint32). Omitted if not applicable.
+  - `idx`: (int, optional) Row index within a potentially multi-row MySQL replication event. Omitted if zero or not applicable.
 
 ## Destination
 
@@ -144,6 +145,7 @@ For Snapshot and CDC modes, the following privileges are required:
 ## Source Configuration Parameters
 
 <!-- readmegen:source.parameters.yaml -->
+
 ```yaml
 version: 2.2
 pipelines:
@@ -151,12 +153,12 @@ pipelines:
     status: running
     connectors:
       - id: example
-        plugin: "mysql"
+        plugin: 'mysql'
         settings:
           # The connection string for the MySQL database.
           # Type: string
           # Required: yes
-          dsn: ""
+          dsn: ''
           # Represents the tables to read from. - By default, no tables are
           # included, but can be modified by adding a comma-separated string of
           # regex patterns. - They are applied in the order that they are
@@ -169,81 +171,83 @@ pipelines:
           # the table "wp_postmeta".
           # Type: string
           # Required: yes
-          tables: ""
+          tables: ''
           # Disables verbose cdc driver logs.
           # Type: bool
           # Required: no
-          cdc.disableLogs: "false"
+          cdc.disableLogs: 'false'
           # Prevents the connector from doing table snapshots and makes it start
           # directly in cdc mode.
           # Type: bool
           # Required: no
-          snapshot.enabled: "false"
+          snapshot.enabled: 'false'
           # Limits how many rows should be retrieved on each database fetch on
           # snapshot mode.
           # Type: int
           # Required: no
-          snapshot.fetchSize: "10000"
+          snapshot.fetchSize: '10000'
           # Allows a snapshot of a table with neither a primary key nor a
           # defined sorting column. The opencdc.Position won't record the last
           # record read from a table.
           # Type: bool
           # Required: no
-          snapshot.unsafe: "false"
+          snapshot.unsafe: 'false'
           # Allows to force using a custom column to sort the snapshot.
           # Type: string
           # Required: no
-          tableConfig.*.sortingColumn: ""
+          tableConfig.*.sortingColumn: ''
           # Maximum delay before an incomplete batch is read from the source.
           # Type: duration
           # Required: no
-          sdk.batch.delay: "0"
+          sdk.batch.delay: '0'
           # Maximum size of batch before it gets read from the source.
           # Type: int
           # Required: no
-          sdk.batch.size: "0"
+          sdk.batch.size: '0'
           # Specifies whether to use a schema context name. If set to false, no
           # schema context name will be used, and schemas will be saved with the
           # subject name specified in the connector (not safe because of name
           # conflicts).
           # Type: bool
           # Required: no
-          sdk.schema.context.enabled: "true"
+          sdk.schema.context.enabled: 'true'
           # Schema context name to be used. Used as a prefix for all schema
           # subject names. If empty, defaults to the connector ID.
           # Type: string
           # Required: no
-          sdk.schema.context.name: ""
+          sdk.schema.context.name: ''
           # Whether to extract and encode the record key with a schema.
           # Type: bool
           # Required: no
-          sdk.schema.extract.key.enabled: "true"
+          sdk.schema.extract.key.enabled: 'true'
           # The subject of the key schema. If the record metadata contains the
           # field "opencdc.collection" it is prepended to the subject name and
           # separated with a dot.
           # Type: string
           # Required: no
-          sdk.schema.extract.key.subject: "key"
+          sdk.schema.extract.key.subject: 'key'
           # Whether to extract and encode the record payload with a schema.
           # Type: bool
           # Required: no
-          sdk.schema.extract.payload.enabled: "true"
+          sdk.schema.extract.payload.enabled: 'true'
           # The subject of the payload schema. If the record metadata contains
           # the field "opencdc.collection" it is prepended to the subject name
           # and separated with a dot.
           # Type: string
           # Required: no
-          sdk.schema.extract.payload.subject: "payload"
+          sdk.schema.extract.payload.subject: 'payload'
           # The type of the payload schema.
           # Type: string
           # Required: no
-          sdk.schema.extract.type: "avro"
+          sdk.schema.extract.type: 'avro'
 ```
+
 <!-- /readmegen:source.parameters.yaml -->
 
 ## Destination Configuration Parameters
 
 <!-- readmegen:destination.parameters.yaml -->
+
 ```yaml
 version: 2.2
 pipelines:
@@ -251,61 +255,62 @@ pipelines:
     status: running
     connectors:
       - id: example
-        plugin: "mysql"
+        plugin: 'mysql'
         settings:
           # The connection string for the MySQL database.
           # Type: string
           # Required: yes
-          dsn: ""
+          dsn: ''
           # Maximum delay before an incomplete batch is written to the
           # destination.
           # Type: duration
           # Required: no
-          sdk.batch.delay: "0"
+          sdk.batch.delay: '0'
           # Maximum size of batch before it gets written to the destination.
           # Type: int
           # Required: no
-          sdk.batch.size: "0"
+          sdk.batch.size: '0'
           # Allow bursts of at most X records (0 or less means that bursts are
           # not limited). Only takes effect if a rate limit per second is set.
           # Note that if `sdk.batch.size` is bigger than `sdk.rate.burst`, the
           # effective batch size will be equal to `sdk.rate.burst`.
           # Type: int
           # Required: no
-          sdk.rate.burst: "0"
+          sdk.rate.burst: '0'
           # Maximum number of records written per second (0 means no rate
           # limit).
           # Type: float
           # Required: no
-          sdk.rate.perSecond: "0"
+          sdk.rate.perSecond: '0'
           # The format of the output record. See the Conduit documentation for a
           # full list of supported formats
           # (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
           # Type: string
           # Required: no
-          sdk.record.format: "opencdc/json"
+          sdk.record.format: 'opencdc/json'
           # Options to configure the chosen output record format. Options are
           # normally key=value pairs separated with comma (e.g.
           # opt1=val2,opt2=val2), except for the `template` record format, where
           # options are a Go template.
           # Type: string
           # Required: no
-          sdk.record.format.options: ""
+          sdk.record.format.options: ''
           # Whether to extract and decode the record key with a schema.
           # Type: bool
           # Required: no
-          sdk.schema.extract.key.enabled: "true"
+          sdk.schema.extract.key.enabled: 'true'
           # Whether to extract and decode the record payload with a schema.
           # Type: bool
           # Required: no
-          sdk.schema.extract.payload.enabled: "true"
+          sdk.schema.extract.payload.enabled: 'true'
 ```
+
 <!-- /readmegen:destination.parameters.yaml -->
 
 ## Testing
 
 Run `make test` to run all tests.
 
-The Docker compose file at `test/docker-compose.yml` can be used to run the required resource locally. It includes [adminer](https://www.adminer.org/) for database management.
+The Docker compose file at `test/docker-compose.yml` can be used to run the required resource locally.
 
 Use the `TRACE=true` environment variable to enable trace logs when running tests.

--- a/common/utils.go
+++ b/common/utils.go
@@ -32,6 +32,7 @@ type CanalConfig struct {
 	*mysql.Config
 	Tables         []string
 	DisableLogging bool
+	Flavor         string // "mysql" or "mariadb"
 }
 
 func NewCanal(ctx context.Context, config CanalConfig) (*canal.Canal, error) {
@@ -39,8 +40,9 @@ func NewCanal(ctx context.Context, config CanalConfig) (*canal.Canal, error) {
 	cfg.Addr = config.Addr
 	cfg.User = config.User
 	cfg.Password = config.Passwd
-
 	cfg.IncludeTableRegex = config.Tables
+	cfg.Flavor = config.Flavor
+
 	if config.DisableLogging {
 		cfg.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	} else {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -3,7 +3,7 @@ networks:
     driver: bridge
 
 services:
-  db:
+  mysql:
     container_name: mysql_db
     image: mysql:8.0.39
     environment:
@@ -21,14 +21,24 @@ services:
       timeout: 20s
       retries: 30
 
-  # Adminer is a web-based SQL management tool. Useful on development
-  adminer:
-    container_name: adminer_ui
-    image: adminer
-    restart: always
-    ports:
-      - 8888:8080
+  mariadb:
+    container_name: mariadb_db
+    image: mariadb:11.4
     environment:
-      ADMINER_DEFAULT_SERVER: mysql_db
+      MARIADB_DATABASE: meroxadb
+      MARIADB_USER: meroxauser
+      MARIADB_PASSWORD: meroxapass
+      MARIADB_ROOT_PASSWORD: meroxaadmin
+    ports:
+      - '3306:3306'
     networks:
       - main
+    command: >-
+      --binlog-format=ROW
+      --log-bin=mysql-bin
+      --server-id=1
+    healthcheck:
+      test: ['CMD', 'mariadb-admin', 'ping', '-h', 'localhost']
+      interval: 1s
+      timeout: 20s
+      retries: 30


### PR DESCRIPTION
### Description

(Continuing work from previous PR, #109)

Checks the db server version and sets the flavor for the NewCanal depending on if it is mariadb or mysql, so that it can use mariadb's native binlog events

Fixes # 108

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.