### PR TITLE
prepare v0.2.0

### DIFF
--- a/connector.yaml
+++ b/connector.yaml
@@ -141,7 +141,7 @@ specification:
     - RELOAD
     - REPLICATION CLIENT
     - REPLICATION SLAVE
-  version: v0.1.4
+  version: v0.2.0
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
This should have been technically 0.2.0.