### PR TITLE
remove dead config.tables parameter

### DIFF
--- a/cdc_iterator.go
+++ b/cdc_iterator.go
@@ -45,7 +45,7 @@ type cdcIteratorConfig struct {
 	db                  *sqlx.DB
 	tables              []string
 	mysqlConfig         *mysqldriver.Config
-	primaryKeys         map[string]common.PrimaryKeys
+	tableKeys           common.TableKeys
 	disableCanalLogging bool
 	startPosition       *common.CdcPosition
 }
@@ -97,7 +97,7 @@ func (c *cdcIterator) start(ctx context.Context) error {
 		c.canal,
 		c.canalDoneC,
 		c.parsedRecordsC,
-		c.config.primaryKeys,
+		c.config.tableKeys,
 		startPosition,
 	)
 
@@ -214,7 +214,7 @@ type cdcEventHandler struct {
 	canalDoneC     chan struct{}
 	parsedRecordsC chan opencdc.Record
 
-	tablePrimaryKeys map[string]common.PrimaryKeys
+	tablePrimaryKeys common.TableKeys
 
 	onRowsChange onRowChangeFn
 }
@@ -224,7 +224,7 @@ func newCdcEventHandler(
 	canal *canal.Canal,
 	canalDoneC chan struct{},
 	parsedRecordsC chan opencdc.Record,
-	tablesPrimaryKeys map[string]common.PrimaryKeys,
+	tablesPrimaryKeys common.TableKeys,
 	startPosition common.CdcPosition,
 ) *cdcEventHandler {
 	h := &cdcEventHandler{

--- a/cdc_iterator_integration_test.go
+++ b/cdc_iterator_integration_test.go
@@ -34,7 +34,7 @@ func testCdcIterator(ctx context.Context, t *testing.T, is *is.I) (common.Iterat
 	iterator, err := newCdcIterator(ctx, cdcIteratorConfig{
 		mysqlConfig:         config,
 		tables:              []string{"users"},
-		primaryKeys:         testutils.TablePrimaryKeys,
+		tableKeys:           testutils.TablePrimaryKeys,
 		db:                  db,
 		disableCanalLogging: true,
 	})
@@ -63,7 +63,7 @@ func testCdcIteratorAtPosition(
 		db:                  db,
 		mysqlConfig:         config,
 		tables:              []string{"users"},
-		primaryKeys:         testutils.TablePrimaryKeys,
+		tableKeys:           testutils.TablePrimaryKeys,
 		startPosition:       pos.CdcPosition,
 		disableCanalLogging: true,
 	})

--- a/combined_iterator.go
+++ b/combined_iterator.go
@@ -36,12 +36,11 @@ type combinedIterator struct {
 
 type combinedIteratorConfig struct {
 	db                    *sqlx.DB
-	primaryKeys           map[string]common.PrimaryKeys
+	tableKeys             common.TableKeys
 	fetchSize             uint64
 	startSnapshotPosition *common.SnapshotPosition
 	startCdcPosition      *common.CdcPosition
 	database              string
-	tables                []string
 	canalRegexes          []string
 	serverID              string
 	mysqlConfig           *mysqldriver.Config
@@ -56,7 +55,7 @@ func newCombinedIterator(
 	cdcIterator, err := newCdcIterator(ctx, cdcIteratorConfig{
 		tables:              config.canalRegexes,
 		mysqlConfig:         config.mysqlConfig,
-		primaryKeys:         config.primaryKeys,
+		tableKeys:           config.tableKeys,
 		disableCanalLogging: config.disableCanalLogging,
 		db:                  config.db,
 		startPosition:       config.startCdcPosition,
@@ -82,11 +81,10 @@ func newCombinedIterator(
 
 	snapshotIterator, err := newSnapshotIterator(snapshotIteratorConfig{
 		db:               config.db,
-		tablePrimaryKeys: config.primaryKeys,
+		tablePrimaryKeys: config.tableKeys,
 		fetchSize:        config.fetchSize,
 		startPosition:    config.startSnapshotPosition,
 		database:         config.database,
-		tables:           config.tables,
 		serverID:         config.serverID,
 	})
 	if err != nil {
@@ -95,7 +93,7 @@ func newCombinedIterator(
 
 	sdk.Logger(ctx).Info().Msg("locking tables to setup fetch workers and obtain cdc start position")
 
-	unlockTables, err := lockTables(ctx, config.db, config.tables)
+	unlockTables, err := lockTables(ctx, config.db, config.tableKeys.GetTables())
 	if err != nil {
 		return nil, err
 	}

--- a/combined_iterator_integration_test.go
+++ b/combined_iterator_integration_test.go
@@ -32,9 +32,8 @@ func testCombinedIterator(ctx context.Context, t *testing.T, is *is.I) (common.I
 
 	iterator, err := newCombinedIterator(ctx, combinedIteratorConfig{
 		db:                  db,
-		primaryKeys:         testutils.TablePrimaryKeys,
+		tableKeys:           testutils.TablePrimaryKeys,
 		database:            "meroxadb",
-		tables:              []string{"users"},
 		serverID:            testutils.ServerID,
 		mysqlConfig:         config,
 		disableCanalLogging: true,

--- a/common/utils.go
+++ b/common/utils.go
@@ -126,16 +126,27 @@ func GetServerID(ctx context.Context, db *sqlx.DB) (string, error) {
 // order is important, so that we can properly build ORDER BY clauses.
 type PrimaryKeys []string
 
+// TableKeys maps table names to their primary keys.
+type TableKeys map[string]PrimaryKeys
+
+func (t TableKeys) GetTables() []string {
+	names := make([]string, 0, len(t))
+	for name := range t {
+		names = append(names, name)
+	}
+	return names
+}
+
 // TableKeyFetcher fetches primary keys from the database and caches them.
 type TableKeyFetcher struct {
 	database string
-	cache    map[string]PrimaryKeys
+	cache    TableKeys
 }
 
 func NewTableKeyFetcher(database string) *TableKeyFetcher {
 	return &TableKeyFetcher{
 		database: database,
-		cache:    make(map[string]PrimaryKeys),
+		cache:    make(TableKeys),
 	}
 }
 

--- a/snapshot_iterator.go
+++ b/snapshot_iterator.go
@@ -56,11 +56,10 @@ type (
 	}
 	snapshotIteratorConfig struct {
 		db               *sqlx.DB
-		tablePrimaryKeys map[string]common.PrimaryKeys
+		tablePrimaryKeys common.TableKeys
 		fetchSize        uint64
 		startPosition    *common.SnapshotPosition
 		database         string
-		tables           []string
 		serverID         string
 	}
 )
@@ -79,8 +78,8 @@ func (config *snapshotIteratorConfig) validate() error {
 	if config.database == "" {
 		return fmt.Errorf("database is required")
 	}
-	if len(config.tables) == 0 {
-		return fmt.Errorf("tables is required")
+	if len(config.tablePrimaryKeys) == 0 {
+		return fmt.Errorf("tablePrimaryKeys is required")
 	}
 
 	return nil

--- a/snapshot_iterator_integration_test.go
+++ b/snapshot_iterator_integration_test.go
@@ -40,7 +40,6 @@ func testSnapshotIterator(ctx context.Context, t *testing.T, is *is.I) (common.I
 		tablePrimaryKeys: testutils.TablePrimaryKeys,
 		db:               db,
 		database:         "meroxadb",
-		tables:           []string{"users"},
 		serverID:         serverID,
 	})
 	is.NoErr(err)
@@ -73,7 +72,6 @@ func testSnapshotIteratorAtPosition(
 		db:               db.SqlxDB,
 		startPosition:    pos.SnapshotPosition,
 		database:         "meroxadb",
-		tables:           []string{"users"},
 		serverID:         serverID,
 	})
 	is.NoErr(err)
@@ -154,7 +152,6 @@ func TestSnapshotIterator_RestartOnPosition(t *testing.T) {
 
 		for len(recs) < 10 {
 			batch, err := it.ReadN(ctx, 5)
-			fmt.Println(len(batch))
 			if errors.Is(err, ErrSnapshotIteratorDone) {
 				for _, rec := range batch {
 					is.NoErr(it.Ack(ctx, rec.Position))
@@ -275,12 +272,11 @@ func TestSnapshotIterator_CustomTableKeys(t *testing.T) {
 			serverID, err := common.GetServerID(ctx, db)
 			is.NoErr(err)
 
-			primaryKeys := map[string]common.PrimaryKeys{testCase.tableName: {testCase.primaryKey}}
+			primaryKeys := common.TableKeys{testCase.tableName: {testCase.primaryKey}}
 			iterator, err := newSnapshotIterator(snapshotIteratorConfig{
 				tablePrimaryKeys: primaryKeys,
 				db:               db,
 				database:         "meroxadb",
-				tables:           []string{testCase.tableName},
 				serverID:         serverID,
 			})
 			is.NoErr(err)
@@ -341,7 +337,6 @@ func TestSnapshotIterator_DeleteEndWhileSnapshotting(t *testing.T) {
 		tablePrimaryKeys: testutils.TablePrimaryKeys,
 		db:               conn,
 		database:         "meroxadb",
-		tables:           []string{"users"},
 		serverID:         serverID,
 	})
 	is.NoErr(err)
@@ -413,10 +408,9 @@ func TestSnapshotIterator_StringSorting(t *testing.T) {
 	is.NoErr(err)
 
 	iterator, err := newSnapshotIterator(snapshotIteratorConfig{
-		tablePrimaryKeys: map[string]common.PrimaryKeys{tablename: {"str"}},
+		tablePrimaryKeys: common.TableKeys{tablename: {"str"}},
 		db:               db.SqlxDB,
 		database:         "meroxadb",
-		tables:           []string{tablename},
 		serverID:         serverID,
 	})
 	is.NoErr(err)
@@ -482,10 +476,9 @@ func TestSnapshotIterator_FetchByLimit(t *testing.T) {
 	is.NoErr(err)
 
 	iterator, err := newSnapshotIterator(snapshotIteratorConfig{
-		tablePrimaryKeys: map[string]common.PrimaryKeys{table1name: {}, table2name: {}},
+		tablePrimaryKeys: common.TableKeys{table1name: {}, table2name: {}},
 		db:               db.SqlxDB,
 		database:         "meroxadb",
-		tables:           []string{table1name, table2name},
 		serverID:         serverID,
 		fetchSize:        10, // small fetch size to test pagination
 	})

--- a/source.go
+++ b/source.go
@@ -167,11 +167,10 @@ func (s *Source) Open(ctx context.Context, sdkPos opencdc.Position) (err error) 
 
 	s.iterator, err = newCombinedIterator(ctx, combinedIteratorConfig{
 		db:                    s.db,
-		primaryKeys:           tableKeys,
+		tableKeys:             tableKeys,
 		startSnapshotPosition: pos.SnapshotPosition,
 		startCdcPosition:      pos.CdcPosition,
 		database:              s.config.MysqlCfg().DBName,
-		tables:                s.config.Tables,
 		canalRegexes:          canalRegexes,
 		serverID:              serverID,
 		mysqlConfig:           s.config.MysqlCfg(),
@@ -328,8 +327,8 @@ func ParseRule(rule string) (Action, string, error) {
 	return action, rule, nil // Return action and regex (without the action prefix)
 }
 
-func (s *Source) getTableKeys(ctx context.Context, dbName string) (map[string]common.PrimaryKeys, error) {
-	tableKeys := make(map[string]common.PrimaryKeys)
+func (s *Source) getTableKeys(ctx context.Context, dbName string) (common.TableKeys, error) {
+	tableKeys := make(common.TableKeys)
 
 	for _, table := range s.config.Tables {
 		preconfiguredTableKey, ok := s.config.TableConfig[table]

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -103,7 +103,7 @@ func TestContext(t *testing.T) context.Context {
 	return logger.WithContext(context.Background())
 }
 
-var TablePrimaryKeys = map[string]common.PrimaryKeys{
+var TablePrimaryKeys = common.TableKeys{
 	"users": {"id"},
 }
 


### PR DESCRIPTION
### Description

Noticed that there was an extra `config.tables` parameter being passed around, which didn't really do anything. This PR cleans it up and adds a new type `common.TableKeys`, which holds table names and their corresponding keys.

I know @hariso that we agreed a few months ago to just keep this data structure as `map[string]common.PrimaryKeys`, but I believe that it is easier overall to pass this data around if it is named properly.

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-mysql/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.